### PR TITLE
Support for query parameters

### DIFF
--- a/mailchimp3/entities/report.py
+++ b/mailchimp3/entities/report.py
@@ -7,11 +7,11 @@ class Report(BaseApi):
         super(Report, self).__init__(*args, **kwargs)
         self.endpoint = 'reports'
 
-    def all(self):
+    def all(self, **kwargs):
         """
-        Returns first 10 reports based on campaign send time.
+        Returns a list of reports.
         """
-        return self._mc_client._get(url=self.endpoint)
+        return self._mc_client._get(url=self.endpoint, **kwargs)
 
     def get(self, report_id):
         """

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -5,6 +5,7 @@ Mailchimp v3 Api SDK
 import requests
 from requests.auth import HTTPBasicAuth
 from urlparse import urljoin
+from urllib import urlencode
 
 
 class MailChimpClient(object):
@@ -28,11 +29,15 @@ class MailChimpClient(object):
         r = requests.post(url, auth=self.auth, json=json)
         return r.json()
 
-    def _get(self, url):
+    def _get(self, url, **kwargs):
         """
-        Handle authenticated POST requests
+        Handle authenticated GET requests
         """
         url = urljoin(self.base_url, url)
+
+        if len(kwargs):
+            url += '?' + urlencode(kwargs)
+
         r = requests.get(url, auth=self.auth)
         return r.json()
 


### PR DESCRIPTION
Added ability to pass in query parameters for GET requests, to support 'count' and 'offset' in mailchimpclient by converting kwargs into query parameters and adding them to the URL for GET requests.

Also added pass-through for kwargs for reports - if this is acceptable, the same could be done for the other entities.