### PR TITLE
Handle passing of GET args.

### DIFF
--- a/mailchimp3/entities/campaign.py
+++ b/mailchimp3/entities/campaign.py
@@ -9,8 +9,8 @@ class Campaign(BaseApi):
         self.endpoint = 'campaigns'
         self.campaign_id = None
 
-    def all(self):
-        return self._mc_client._get(url=self.endpoint)
+    def all(self, **kwargs):
+        return self._mc_client._get(url=self.endpoint, **kwargs)
 
     def get(self, campaign_id):
         self.campaign_id = campaign_id

--- a/mailchimp3/entities/member.py
+++ b/mailchimp3/entities/member.py
@@ -7,11 +7,11 @@ class Member(BaseApi):
         super(Member, self).__init__(*args, **kwargs)
         self.endpoint = 'lists'
 
-    def all(self, list_id):
+    def all(self, list_id, **kwargs):
         """
         returns the first 10 members for a specific list.
         """
-        return self._mc_client._get(url=self._build_path(list_id, 'members'))
+        return self._mc_client._get(url=self._build_path(list_id, 'members'), **kwargs)
 
     def get(self, list_id, member_id):
         """


### PR DESCRIPTION
The Mailchimp API often accepts optional GET arguments in a call - I've tweaked your code to allow these to be passed. It covers the specific endpoints where I required that functionality!