### PR TITLE
Use unicode_literals

### DIFF
--- a/mailchimp3/entities/authorizedapp.py
+++ b/mailchimp3/entities/authorizedapp.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/automation.py
+++ b/mailchimp3/entities/automation.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/automationemail.py
+++ b/mailchimp3/entities/automationemail.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/automationemailqueue.py
+++ b/mailchimp3/entities/automationemailqueue.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/automationeremovedsubscriber.py
+++ b/mailchimp3/entities/automationeremovedsubscriber.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/campaign.py
+++ b/mailchimp3/entities/campaign.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 from .feedback import Feedback
 

--- a/mailchimp3/entities/category.py
+++ b/mailchimp3/entities/category.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/client.py
+++ b/mailchimp3/entities/client.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/conversation.py
+++ b/mailchimp3/entities/conversation.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/feedback.py
+++ b/mailchimp3/entities/feedback.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/files.py
+++ b/mailchimp3/entities/files.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/folder.py
+++ b/mailchimp3/entities/folder.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/goal.py
+++ b/mailchimp3/entities/goal.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/growth.py
+++ b/mailchimp3/entities/growth.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/interest.py
+++ b/mailchimp3/entities/interest.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/list.py
+++ b/mailchimp3/entities/list.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/listabuse.py
+++ b/mailchimp3/entities/listabuse.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/listactivity.py
+++ b/mailchimp3/entities/listactivity.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/member.py
+++ b/mailchimp3/entities/member.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/memberactivity.py
+++ b/mailchimp3/entities/memberactivity.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/message.py
+++ b/mailchimp3/entities/message.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/report.py
+++ b/mailchimp3/entities/report.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/reportabuse.py
+++ b/mailchimp3/entities/reportabuse.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/reportactivity.py
+++ b/mailchimp3/entities/reportactivity.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/entities/root.py
+++ b/mailchimp3/entities/root.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 from .feedback import Feedback
 

--- a/mailchimp3/entities/template.py
+++ b/mailchimp3/entities/template.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from ..baseapi import BaseApi
 
 

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -2,6 +2,9 @@
 Mailchimp v3 Api SDK
 
 """
+
+from __future__ import unicode_literals
+
 import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import InvalidURL, HTTPError


### PR DESCRIPTION
Fix an error on Python 2.x when attempting to `urljoin` base_url with a unicode URL.`

Traceback takes the form:
```
Traceback (most recent call last):
  <snipped>
  File "VIRTUAL_ENV/local/lib/python2.7/site-packages/mailchimp3/mailchimpclient.py", line 49, in _get
    url = urljoin(self.base_url, url)
  File "VIRTUAL_ENV/local/lib/python2.7/site-packages/future/backports/urllib/parse.py", line 418, in urljoin
    base, url, _coerce_result = _coerce_args(base, url)
  File "VIRTUAL_ENV/local/lib/python2.7/site-packages/future/backports/urllib/parse.py", line 115, in _coerce_args
    raise TypeError("Cannot mix str and non-str arguments")
TypeError: Cannot mix str and non-str arguments
```