### PR TITLE
Adding optional `enabled` flag to MailChimpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Grab `YOUR SECRET KEY` from your mailchimp account (Account > Extra > Api Keys).
     # returns all the campaigns
     client.campaign.all()
 
+    # You can also disable at runtime with the optional `enabled` parameter.
+    # Every API call will return None
+    client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', enabled=False)
 
 ### Pagination
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,10 @@ Examples
     # returns all the campaigns
     client.campaign.all()
 
+    # You can also disable at runtime with the optional ``enabled`` parameter.
+    # Every API call will return None
+    client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', enabled=False)
+
 Pagination
 ~~~~~~~~~~
 

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -4,6 +4,7 @@ Mailchimp v3 Api SDK
 """
 
 from __future__ import unicode_literals
+import functools
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -17,20 +18,33 @@ except ImportError:
     from urllib import urlencode
 
 
+def _enabled_or_noop(fn):
+    @functools.wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        if self.enabled:
+            return fn(self, *args, **kwargs)
+    return wrapper
+
+
 class MailChimpClient(object):
     """
     MailChimp class to communicate with the v3 API
     """
 
-    def __init__(self, mc_user, mc_secret):
+    def __init__(self, mc_user, mc_secret, enabled=True):
         """
-        Initialize the class with you user_id and secret_key
+        Initialize the class with you user_id and secret_key.
+
+        If `enabled` is not True, these methods become no-ops. This is
+        particularly useful for testing or disabling with configuration.
         """
         super(MailChimpClient, self).__init__()
+        self.enabled = enabled
         self.auth = HTTPBasicAuth(mc_user, mc_secret)
         datacenter = mc_secret.split('-').pop()
         self.base_url = 'https://%s.api.mailchimp.com/3.0/' % datacenter
 
+    @_enabled_or_noop
     def _post(self, url, data=None):
         """
         Handle authenticated POST requests
@@ -44,6 +58,7 @@ class MailChimpClient(object):
         else:
             raise HTTPError(request=r)
 
+    @_enabled_or_noop
     def _get(self, url, **queryparams):
         """
         Handle authenticated GET requests
@@ -59,6 +74,7 @@ class MailChimpClient(object):
             raise e
         return r.json()
 
+    @_enabled_or_noop
     def _delete(self, url):
         """
         Handle authenticated DELETE requests
@@ -71,6 +87,7 @@ class MailChimpClient(object):
         else:
             return
 
+    @_enabled_or_noop
     def _patch(self, url, data=None):
         """
         Handle authenticated PATH requests
@@ -79,6 +96,7 @@ class MailChimpClient(object):
         r = requests.patch(url, auth=self.auth, json=data)
         return r.json()
 
+    @_enabled_or_noop
     def _put(self, url, data=None):
         """
         Handle authenticated PUT requests


### PR DESCRIPTION
* If client is not enabled all API calls return None vs raising and exception
* Allows us to enable/disable easily with configuration management (chef, docker/etcd, yaml, whatever) without writing a bunch of conditionals in Python

My use case:

```python
# file: mailchimp_integration.py
# ------------------------------
from mailchimp3 import MailChimp

import config

client = MailChimp(config.mailchimp_user, config.mailchimp_secret, 
                   enabled=config.mailchimp_enabled)

def subscribe(user):
    return client.member.create(list_id, data=user)


# file: subscriptions.py
# ----------------------
...
mailchimp_integration.subscribe(user)
...