### PR TITLE
Update exceptions to be python 3 friendly

### DIFF
--- a/mailchimp3/entities/authorizedapps.py
+++ b/mailchimp3/entities/authorizedapps.py
@@ -7,6 +7,9 @@ Schema: http://api.mailchimp.com/schema/3.0/AuthorizedApps/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -40,13 +43,13 @@ class AuthorizedApps(BaseApi):
         try:
             test = data['client_id']
         except KeyError as error:
-            error.message += ' The authorized app must have a client_id'
-            raise
+            new_msg = 'The authorized app must have a client_id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['client_secret']
         except KeyError as error:
-            error.message += ' The authorized app must have a client_secret'
-            raise
+            new_msg = 'The authorized app must have a client_secret, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._post(url=self._build_path(), data=data)
 
 

--- a/mailchimp3/entities/automationemailqueues.py
+++ b/mailchimp3/entities/automationemailqueues.py
@@ -9,6 +9,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Automations/Emails/Queue/Instance.j
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email, check_subscriber_hash
 
@@ -50,8 +53,8 @@ class AutomationEmailQueues(BaseApi):
         try:
             test = data['email_address']
         except KeyError as error:
-            error.message += ' The automation email queue must have an email_address'
-            raise
+            new_msg = 'The automation email queue must have an email_address, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['email_address'])
         response = self._mc_client._post(
             url=self._build_path(workflow_id, 'emails', email_id, 'actions/pause-all-emails'),

--- a/mailchimp3/entities/automationremovedsubscribers.py
+++ b/mailchimp3/entities/automationremovedsubscribers.py
@@ -9,6 +9,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Automations/RemovedSubscribers/Inst
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email
 
@@ -45,8 +48,8 @@ class AutomationRemovedSubscribers(BaseApi):
         try:
             test = data['email_address']
         except KeyError as error:
-            error.message += ' The automation removed subscriber must have an email_address'
-            raise
+            new_msg = 'The automation removed subscriber must have an email_address, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['email_address'])
         return self._mc_client._post(url=self._build_path(workflow_id, 'removed-subscribers'), data=data)
 

--- a/mailchimp3/entities/batches.py
+++ b/mailchimp3/entities/batches.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Batches/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -43,22 +46,22 @@ class Batches(BaseApi):
         try:
             test = data['operations']
         except KeyError as error:
-            error.message += ' The batch must have operations'
-            raise
+            new_msg = 'The batch must have operations, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         for op in data['operations']:
             try:
                 test = op['method']
             except KeyError as error:
-                error.message += ' The batch operation must have a method'
-                raise
+                new_msg = 'The batch operation must have a method, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             if op['method'] not in ['GET', 'POST', 'PUT', 'PATCH']:
                 raise ValueError('The batch operation method must be one of "GET", "POST", "PUT", or "PATCH", not {0}'
                                  ''.format(op['method']))
             try:
                 test = op['path']
             except KeyError as error:
-                error.message += ' The batch operation must have a path'
-                raise
+                new_msg = 'The batch operation must have a path, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._post(url=self._build_path(), data=data)
 
 

--- a/mailchimp3/entities/campaignfeedback.py
+++ b/mailchimp3/entities/campaignfeedback.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Campaigns/Feedback/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -44,8 +47,8 @@ class CampaignFeedback(BaseApi):
         try:
             test = data['message']
         except KeyError as error:
-            error.message += ' The campaign feedback must have a message'
-            raise
+            new_msg = 'The campaign feedback must have a message, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(campaign_id, 'feedback'), data=data, **queryparams)
         if response is not None:
             self.feedback_id = response['feedback_id']
@@ -111,8 +114,8 @@ class CampaignFeedback(BaseApi):
         try:
             test = data['message']
         except KeyError as error:
-            error.message += ' The campaign feedback must have a message'
-            raise
+            new_msg = 'The campaign feedback must have a message, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(url=self._build_path(campaign_id, 'feedback', feedback_id), data=data)
 
 

--- a/mailchimp3/entities/campaignfolders.py
+++ b/mailchimp3/entities/campaignfolders.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/CampaignFolders/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -36,8 +39,8 @@ class CampaignFolders(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The campaign folder must have a name'
-            raise
+            new_msg = 'The campaign folder must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.folder_id = response['id']
@@ -95,8 +98,8 @@ class CampaignFolders(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The campaign folder must have a name'
-            raise
+            new_msg = 'The campaign folder must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(url=self._build_path(folder_id), data=data)
 
 

--- a/mailchimp3/entities/campaigns.py
+++ b/mailchimp3/entities/campaigns.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Campaigns/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.campaignactions import CampaignActions
 from mailchimp3.entities.campaigncontent import CampaignContent
@@ -69,43 +72,43 @@ class Campaigns(BaseApi):
         try:
             test = data['recipients']
         except KeyError as error:
-            error.message += ' The campaign must have recipients'
-            raise
+            new_msg = 'The campaign must have recipients, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         for recipient in data['recipients']:
             try:
                 test = recipient['list_id']
             except KeyError as error:
-                error.message += ' The campaign recipient must have a list_id'
-                raise
+                new_msg = 'The campaign recipient must have a list_id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['settings']['subject_line']
         except KeyError as error:
-            error.message += ' The campaign settings must have a subject_line'
-            raise
+            new_msg = 'The campaign settings must have a subject_line, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['settings']['from_name']
         except KeyError as error:
-            error.message += ' The campaign settings must have a from_name'
-            raise
+            new_msg = 'The campaign settings must have a from_name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['settings']['reply_to']
         except KeyError as error:
-            error.message += ' The campaign settings must have a reply_to'
-            raise
+            new_msg = 'The campaign settings must have a reply_to, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['settings']['reply_to'])
         try:
             test = data['type']
         except KeyError as error:
-            error.message += ' The campaign must have a type'
-            raise
+            new_msg = 'The campaign must have a type, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if not data['type'] in ['regular', 'plaintext', 'rss', 'variate', 'abspilt']:
             raise ValueError('The campaign type must be one of "regular", "plaintext", "rss", or "variate"')
         if data['type'] == 'variate':
             try:
                 test = data['variate_settings']['winner_criteria']
             except KeyError as error:
-                error.message += 'The campaign variate_settings must have a winner_criteria'
-                raise
+                new_msg = 'The campaign variate_settings must have a winner_criteria, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             if data['variate_settings']['winner_criteria'] not in ['opens', 'clicks', 'total_revenue', 'manual']:
                 raise ValueError('The campaign variate_settings '
                                  'winner_criteria must be one of "opens", "clicks", "total_revenue", or "manual"')
@@ -113,8 +116,8 @@ class Campaigns(BaseApi):
             try:
                 test = data['rss_opts']['feed_url']
             except KeyError as error:
-                error.message += ' The campaign rss_opts must have a feed_url'
-                raise
+                new_msg = 'The campaign rss_opts must have a feed_url, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             if not data['rss_opts']['frequency'] in ['daily', 'weekly', 'monthly']:
                 raise ValueError('The rss_opts frequency must be one of "daily", "weekly", or "monthly"')
         response = self._mc_client._post(url=self._build_path(), data=data)
@@ -187,23 +190,23 @@ class Campaigns(BaseApi):
         try:
             test = data['settings']
         except KeyError as error:
-            error.message += ' The campaign must have settings'
-            raise
+            new_msg = 'The campaign must have settings, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['settings']['subject_line']
         except KeyError as error:
-            error.message += ' The campaign settings must have a subject_line'
-            raise
+            new_msg = 'The campaign settings must have a subject_line, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['settings']['from_name']
         except KeyError as error:
-            error.message += ' The campaign settings must have a from_name'
-            raise
+            new_msg = 'The campaign settings must have a from_name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['settings']['reply_to']
         except KeyError as error:
-            error.message += ' The campaign settings must have a reply_to'
-            raise
+            new_msg = 'The campaign settings must have a reply_to, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['settings']['reply_to'])
         return self._mc_client._patch(url=self._build_path(campaign_id), data=data)
 

--- a/mailchimp3/entities/conversationmessages.py
+++ b/mailchimp3/entities/conversationmessages.py
@@ -9,6 +9,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Conversations/Messages/Instance.jso
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email
 
@@ -45,14 +48,14 @@ class ConversationMessages(BaseApi):
         try:
             test = data['from_email']
         except KeyError as error:
-            error.message += ' The conversation message must have a from_email'
-            raise
+            new_msg = 'The conversation message must have a from_email, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['from_email'])
         try:
             test = data['read']
         except KeyError as error:
-            error.message += ' The conversation message must have a read'
-            raise
+            new_msg = 'The conversation message must have a read, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['read'] not in [True, False]:
             raise TypeError('The conversation message read must be True or False')
         response =  self._mc_client._post(url=self._build_path(conversation_id, 'messages'), data=data)

--- a/mailchimp3/entities/filemanagerfiles.py
+++ b/mailchimp3/entities/filemanagerfiles.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/FileManager/Files/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -39,13 +42,13 @@ class FileManagerFiles(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The file must have a name'
-            raise
+            new_msg = 'The file must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['file_data']
         except KeyError as error:
-            error.message += ' The file must have file_data'
-            raise
+            new_msg = 'The file must have file_data, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.file_id = response['id']
@@ -110,13 +113,13 @@ class FileManagerFiles(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The file must have a name'
-            raise
+            new_msg = 'The file must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['file_data']
         except KeyError as error:
-            error.message += ' The file must have file_data'
-            raise
+            new_msg = 'The file must have file_data, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(url=self._build_path(file_id), data=data)
 
 

--- a/mailchimp3/entities/filemanagerfolders.py
+++ b/mailchimp3/entities/filemanagerfolders.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/FileManager/Folders/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -38,8 +41,8 @@ class FileManagerFolders(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The folder must have a name'
-            raise
+            new_msg = 'The folder must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.folder_id = response['id']
@@ -100,8 +103,8 @@ class FileManagerFolders(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The folder must have a name'
-            raise
+            new_msg = 'The folder must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(url=self._build_path(folder_id), data=data)
 
 

--- a/mailchimp3/entities/listinterestcategories.py
+++ b/mailchimp3/entities/listinterestcategories.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.j
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listinterestcategoryinterest import ListInterestCategoryInterest
 
@@ -46,13 +49,13 @@ class ListInterestCategories(BaseApi):
         try:
             test = data['title']
         except KeyError as error:
-            error.message += ' The list interest category must have a title'
-            raise
+            new_msg = 'The list interest category must have a title, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['type']
         except KeyError as error:
-            error.message += ' The list interest category must have a type'
-            raise
+            new_msg = 'The list interest category must have a type, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['type'] not in ['checkboxes', 'dropdown', 'radio', 'hidden']:
             raise ValueError('The list interest category type must be one of "checkboxes", "dropdown", "radio", or '
                              '"hidden"')
@@ -124,13 +127,13 @@ class ListInterestCategories(BaseApi):
         try:
             test = data['title']
         except KeyError as error:
-            error.message += ' The list interest category must have a title'
-            raise
+            new_msg = 'The list interest category must have a title, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['type']
         except KeyError as error:
-            error.message += ' The list interest category must have a type'
-            raise
+            new_msg = 'The list interest category must have a type, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['type'] not in ['checkboxes', 'dropdown', 'radio', 'hidden']:
             raise ValueError('The list interest category type must be one of "checkboxes", "dropdown", "radio", or '
                              '"hidden"')

--- a/mailchimp3/entities/listinterestcategoryinterest.py
+++ b/mailchimp3/entities/listinterestcategoryinterest.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -50,8 +53,8 @@ class ListInterestCategoryInterest(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list interest category interest must have a name'
-            raise
+            new_msg = 'The list interest category interest must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response =  self._mc_client._post(
             url=self._build_path(list_id, 'interest-categories', category_id, 'interests'),
             data=data
@@ -136,8 +139,8 @@ class ListInterestCategoryInterest(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list interest category interest must have a name'
-            raise
+            new_msg = 'The list interest category interest must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(
             url=self._build_path(list_id, 'interest-categories', category_id, 'interests', interest_id),
             data=data

--- a/mailchimp3/entities/listmembernotes.py
+++ b/mailchimp3/entities/listmembernotes.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Members/Notes/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_subscriber_hash
 
@@ -51,8 +54,8 @@ class ListMemberNotes(BaseApi):
         try:
             test = data['note']
         except KeyError as error:
-            error.message += ' The list member note must have a note'
-            raise
+            new_msg = 'The list member note must have a note, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(list_id, 'members', subscriber_hash, 'notes'), data=data)
         if response is not None:
             self.note_id = response['id']
@@ -141,8 +144,8 @@ class ListMemberNotes(BaseApi):
         try:
             test = data['note']
         except KeyError as error:
-            error.message += ' The list member note must have a note'
-            raise
+            new_msg = 'The list member note must have a note, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(
             url=self._build_path(list_id, 'members', subscriber_hash, 'notes', note_id),
             data=data

--- a/mailchimp3/entities/listmembers.py
+++ b/mailchimp3/entities/listmembers.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Members/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listmemberactivity import ListMemberActivity
 from mailchimp3.entities.listmembergoals import ListMemberGoals
@@ -49,16 +52,16 @@ class ListMembers(BaseApi):
         try:
             test = data['status']
         except KeyError as error:
-            error.message += ' The list member must have a status'
-            raise
+            new_msg = 'The list member must have a status, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['status'] not in ['subscribed', 'unsubscribed', 'cleaned', 'pending']:
             raise ValueError('The list member status must be one of "subscribed", "unsubscribed", "cleaned", or '
                              '"pending"')
         try:
             test = data['email_address']
         except KeyError as error:
-            error.message += ' The list member must have an email_address'
-            raise
+            new_msg = 'The list member must have an email_address, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['email_address'])
         response = self._mc_client._post(url=self._build_path(list_id, 'members'), data=data)
         if response is not None:
@@ -161,14 +164,14 @@ class ListMembers(BaseApi):
         try:
             test = data['email_address']
         except KeyError as error:
-            error.message += ' The list member must have an email_address'
-            raise
+            new_msg = 'The list member must have an email_address, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['email_address'])
         try:
             test = data['status_if_new']
         except KeyError as error:
-            error.message += ' The list member must have a status_if_new'
-            raise
+            new_msg = 'The list member must have a status_if_new, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['status_if_new'] not in ['subscribed', 'unsubscribed', 'cleaned', 'pending']:
             raise ValueError('The list member status_if_new must be one of "subscribed", "unsubscribed", "cleaned", '
                              'or "pending"')

--- a/mailchimp3/entities/listmergefields.py
+++ b/mailchimp3/entities/listmergefields.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/MergeFields/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -41,13 +44,13 @@ class ListMergeFields(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list merge field must have a name'
-            raise
+            new_msg = 'The list merge field must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['type']
         except KeyError as error:
-            error.message += ' The list merge field must have a type'
-            raise
+            new_msg = 'The list merge field must have a type, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(list_id, 'merge-fields'), data=data)
         if response is not None:
             self.merge_id = response['id']
@@ -113,8 +116,8 @@ class ListMergeFields(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list merge field must have a name'
-            raise
+            new_msg = 'The list merge field must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(url=self._build_path(list_id, 'merge-fields', merge_id), data=data)
 
 

--- a/mailchimp3/entities/lists.py
+++ b/mailchimp3/entities/lists.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listabusereports import ListAbuseReports
 from mailchimp3.entities.listactivity import ListActivity
@@ -77,79 +80,79 @@ class Lists(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list must have a name'
-            raise
+            new_msg = 'The list must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']
         except KeyError as error:
-            error.message += ' The list must have a contact'
-            raise
+            new_msg = 'The list must have a contact, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['company']
         except KeyError as error:
-            error.message += ' The list contact must have a company'
-            raise
+            new_msg = 'The list contact must have a company, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['address1']
         except KeyError as error:
-            error.message += ' The list contact must have a address1'
-            raise
+            new_msg = 'The list contact must have a address1, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['city']
         except KeyError as error:
-            error.message += ' The list contact must have a city'
-            raise
+            new_msg = 'The list contact must have a city, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['state']
         except KeyError as error:
-            error.message += ' The list contact must have a state'
-            raise
+            new_msg = 'The list contact must have a state, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['zip']
         except KeyError as error:
-            error.message += ' The list contact must have a zip'
-            raise
+            new_msg = 'The list contact must have a zip, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['country']
         except KeyError as error:
-            error.message += ' The list contact must have a country'
-            raise
+            new_msg = 'The list contact must have a country, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['permission_reminder']
         except KeyError as error:
-            error.message += ' The list must have a permission_reminder'
-            raise
+            new_msg = 'The list must have a permission_reminder, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']
         except KeyError as error:
-            error.message += ' The list must have a campaign_defaults'
-            raise
+            new_msg = 'The list must have a campaign_defaults, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']['from_name']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a from_name'
-            raise
+            new_msg = 'The list campaign_defaults must have a from_name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']['from_email']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a from_email'
-            raise
+            new_msg = 'The list campaign_defaults must have a from_email, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['campaign_defaults']['from_email'])
         try:
             test = data['campaign_defaults']['subject']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a subject'
-            raise
+            new_msg = 'The list campaign_defaults must have a subject, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']['language']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a language'
-            raise
+            new_msg = 'The list campaign_defaults must have a language, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['email_type_option']
         except KeyError as error:
-            error.message += ' The list must have an email_type_option'
-            raise
+            new_msg = 'The list must have an email_type_option, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['email_type_option'] not in [True, False]:
             raise TypeError('The list email_type_option must be True or False')
         response = self._mc_client._post(url=self._build_path(), data=data)
@@ -192,20 +195,20 @@ class Lists(BaseApi):
             if not len(test) <= 500:
                 raise ValueError('You may only batch sub/unsub 500 members at a time')
         except KeyError as error:
-            error.message += ' The update must have at least one member'
-            raise
+            new_msg = 'The update must have at least one member, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         for member in data['members']:
             try:
                 test = member['email_address']
             except KeyError as error:
-                error.message += ' Each list member must have an email_address'
-                raise
+                new_msg = 'Each list member must have an email_address, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             check_email(member['email_address'])
             try:
                 test = member['status']
             except KeyError as error:
-                error.message += ' Each list member must have a status'
-                raise
+                new_msg = 'Each list member must have a status, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             if member['status'] not in ['subscribed', 'unsubscribed', 'cleaned', 'pending']:
                 raise ValueError('The list member status must be one of "subscribed", "unsubscribed", "cleaned", or '
                                  '"pending"')
@@ -290,79 +293,79 @@ class Lists(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list must have a name'
-            raise
+            new_msg = 'The list must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']
         except KeyError as error:
-            error.message += ' The list must have a contact'
-            raise
+            new_msg = 'The list must have a contact, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['company']
         except KeyError as error:
-            error.message += ' The list contact must have a company'
-            raise
+            new_msg = 'The list contact must have a company, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['address1']
         except KeyError as error:
-            error.message += ' The list contact must have a address1'
-            raise
+            new_msg = 'The list contact must have a address1, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['city']
         except KeyError as error:
-            error.message += ' The list contact must have a city'
-            raise
+            new_msg = 'The list contact must have a city, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['state']
         except KeyError as error:
-            error.message += ' The list contact must have a state'
-            raise
+            new_msg = 'The list contact must have a state, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['zip']
         except KeyError as error:
-            error.message += ' The list contact must have a zip'
-            raise
+            new_msg = 'The list contact must have a zip, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['contact']['country']
         except KeyError as error:
-            error.message += ' The list contact must have a country'
-            raise
+            new_msg = 'The list contact must have a country, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['permission_reminder']
         except KeyError as error:
-            error.message += ' The list must have a permission_reminder'
-            raise
+            new_msg = 'The list must have a permission_reminder, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']
         except KeyError as error:
-            error.message += ' The list must have a campaign_defaults'
-            raise
+            new_msg = 'The list must have a campaign_defaults, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']['from_name']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a from_name'
-            raise
+            new_msg = 'The list campaign_defaults must have a from_name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']['from_email']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a from_email'
-            raise
+            new_msg = 'The list campaign_defaults must have a from_email, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['campaign_defaults']['from_email'])
         try:
             test = data['campaign_defaults']['subject']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a subject'
-            raise
+            new_msg = 'The list campaign_defaults must have a subject, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['campaign_defaults']['language']
         except KeyError as error:
-            error.message += ' The list campaign_defaults must have a language'
-            raise
+            new_msg = 'The list campaign_defaults must have a language, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['email_type_option']
         except KeyError as error:
-            error.message += ' The list must have an email_type_option'
-            raise
+            new_msg = 'The list must have an email_type_option, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['email_type_option'] not in [True, False]:
             raise TypeError('The list email_type_option must be True or False')
         return self._mc_client._patch(url=self._build_path(list_id), data=data)

--- a/mailchimp3/entities/listsegmentmembers.py
+++ b/mailchimp3/entities/listsegmentmembers.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Members/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email, check_subscriber_hash
 
@@ -51,14 +54,14 @@ class ListSegmentMembers(BaseApi):
         try:
             test = data['email_address']
         except KeyError as error:
-            error.message += ' The list segment member must have an email_address'
-            raise
+            new_msg = 'The list segment member must have an email_address, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['email_address'])
         try:
             test = data['status']
         except KeyError as error:
-            error.message += ' The list segment member must have a status'
-            raise
+            new_msg = 'The list segment member must have a status, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['status'] not in ['subscribed', 'unsubscribed', 'cleaned', 'pending']:
             raise ValueError('The list segment member status must be one of "subscribed", "unsubscribed", "cleaned" or'
                              '"pending"')

--- a/mailchimp3/entities/listsegments.py
+++ b/mailchimp3/entities/listsegments.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Segments/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listsegmentmembers import ListSegmentMembers
 
@@ -44,8 +47,8 @@ class ListSegments(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list segment must have a name'
-            raise
+            new_msg = 'The list segment must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(list_id, 'segments'), data=data)
         if response is not None:
             self.segment_id = response['id']
@@ -117,8 +120,8 @@ class ListSegments(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The list segment must have a name'
-            raise
+            new_msg = 'The list segment must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._patch(url=self._build_path(list_id, 'segments', segment_id), data=data)
 
 

--- a/mailchimp3/entities/listtwitterleadgenerationcards.py
+++ b/mailchimp3/entities/listtwitterleadgenerationcards.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/TwitterLeadGenCards/Instance.
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_url
 
@@ -46,37 +49,37 @@ class ListTwitterLeadGenerationCards(BaseApi):
         try:
             data['name']
         except KeyError as error:
-            error.message += ' The twitter lead generation card must have a name'
-            raise
+            new_msg = 'The twitter lead generation card must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             data['title']
         except KeyError as error:
-            error.message += ' The twitter lead generation card must have a title'
-            raise
+            new_msg = 'The twitter lead generation card must have a title, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             data['cta_text']
         except KeyError as error:
-            error.message += ' The twitter lead generation card must have a cta_text'
-            raise
+            new_msg = 'The twitter lead generation card must have a cta_text, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if len(data['cta_text']) > 20:
             raise ValueError('The twitter lead generation card cta_text must be 20 characters or less')
         try:
             data['privacy_policy_url']
         except KeyError as error:
-            error.message += ' The twitter lead generation card must have a privacy_policy_url'
-            raise
+            new_msg = 'The twitter lead generation card must have a privacy_policy_url, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_url(data['privacy_policy_url'])
         try:
             data['image_url']
         except KeyError as error:
-            error.message += ' The twitter lead generation card must have a image_url'
-            raise
+            new_msg = 'The twitter lead generation card must have a image_url, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_url(data['image_url'])
         try:
             data['twitter_account_id']
         except KeyError as error:
-            error.message += ' The twitter lead generation card must have a twitter_account_id'
-            raise
+            new_msg = 'The twitter lead generation card must have a twitter_account_id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(list_id, 'twitter-lead-gen-cards'), data=data)
         if response is not None:
             self.twitter_card_id = response['id']

--- a/mailchimp3/entities/listwebhooks.py
+++ b/mailchimp3/entities/listwebhooks.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Webhooks/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_url
 
@@ -46,8 +49,8 @@ class ListWebhooks(BaseApi):
         try:
             test = data['url']
         except KeyError as error:
-            error.message += ' The list webhook must have a url'
-            raise
+            new_msg = 'The list webhook must have a url, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_url(data['url'])
         response = self._mc_client._post(url=self._build_path(list_id, 'webhooks'), data=data)
         if response is not None:

--- a/mailchimp3/entities/storecartlines.py
+++ b/mailchimp3/entities/storecartlines.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Carts/Lines/Instan
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -49,28 +52,28 @@ class StoreCartLines(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The cart line must have an id'
-            raise
+            new_msg = 'The cart line must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['product_id']
         except KeyError as error:
-            error.message += ' The cart line must have a product_id'
-            raise
+            new_msg = 'The cart line must have a product_id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['product_variant_id']
         except KeyError as error:
-            error.message += ' The cart line must have a product_variant_id'
-            raise
+            new_msg = 'The cart line must have a product_variant_id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['quantity']
         except KeyError as error:
-            error.message += ' The cart line must have a quantity'
-            raise
+            new_msg = 'The cart line must have a quantity, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['price']
         except KeyError as error:
-            error.message += ' The cart line must have a price'
-            raise
+            new_msg = 'The cart line must have a price, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(store_id, 'carts', cart_id, 'lines'), data=data)
         if response is not None:
             self.line_id = response['id']

--- a/mailchimp3/entities/storecarts.py
+++ b/mailchimp3/entities/storecarts.py
@@ -8,6 +8,8 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Carts/Instance.jso
 from __future__ import unicode_literals
 
 import re
+import six
+import sys
 
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storecartlines import StoreCartLines
@@ -62,61 +64,61 @@ class StoreCarts(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The cart must have an id'
-            raise
+            new_msg = 'The cart must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['customer']
         except KeyError as error:
-            error.message += ' The cart must have a customer'
-            raise
+            new_msg = 'The cart must have a customer, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['customer']['id']
         except KeyError as error:
-            error.message += ' The cart customer must have an id'
-            raise
+            new_msg = 'The cart customer must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['currency_code']
         except KeyError as error:
-            error.message += ' The cart must have a currency_code'
-            raise
+            new_msg = 'The cart must have a currency_code, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if not re.match(r"^[A-Z]{3}$", data['currency_code']):
             raise ValueError('The currency_code must be a valid 3-letter ISO 4217 currency code')
         try:
             test = data['order_total']
         except KeyError as error:
-            error.message += ' The cart must have an order_total'
-            raise
+            new_msg = 'The cart must have an order_total, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['lines']
         except KeyError as error:
-            error.message += ' The cart must have at least one cart line'
-            raise
+            new_msg = 'The cart must have at least one cart line, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         for line in data['lines']:
             try:
                 test = line['id']
             except KeyError as error:
-                error.message += ' Each cart line must have an id'
-                raise
+                new_msg = 'Each cart line must have an id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['product_id']
             except KeyError as error:
-                error.message += ' Each cart line must have a product_id'
-                raise
+                new_msg = 'Each cart line must have a product_id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['product_variant_id']
             except KeyError as error:
-                error.message += ' Each cart line must have a product_variant_id'
-                raise
+                new_msg = 'Each cart line must have a product_variant_id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['quantity']
             except KeyError as error:
-                error.message += ' Each cart line must have a quantity'
-                raise
+                new_msg = 'Each cart line must have a quantity, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['price']
             except KeyError as error:
-                error.message += ' Each cart line must have a price'
-                raise
+                new_msg = 'Each cart line must have a price, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(store_id, 'carts'), data=data)
         if response is not None:
             self.cart_id = response['id']

--- a/mailchimp3/entities/storecustomers.py
+++ b/mailchimp3/entities/storecustomers.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Customers/Instance
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email
 
@@ -46,19 +49,19 @@ class StoreCustomers(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The store customer must have an id'
-            raise
+            new_msg = 'The store customer must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['email_address']
         except KeyError as error:
-            error.message += ' The store customer must have an email_address'
-            raise
+            new_msg = 'The store customer must have an email_address, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['email_address'])
         try:
             test = data['opt_in_status']
         except KeyError as error:
-            error.message += ' The store customer must have an opt_in_status'
-            raise
+            new_msg = 'The store customer must have an opt_in_status, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['opt_in_status'] not in [True, False]:
             raise TypeError('The opt_in_status must be True or False')
         response = self._mc_client._post(url=self._build_path(store_id, 'customers'), data=data)
@@ -146,19 +149,19 @@ class StoreCustomers(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The store customer must have an id'
-            raise
+            new_msg = 'The store customer must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['email_address']
         except KeyError as error:
-            error.message += ' Each store customer must have an email_address'
-            raise
+            new_msg = 'Each store customer must have an email_address, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         check_email(data['email_address'])
         try:
             test = data['opt_in_status']
         except KeyError as error:
-            error.message += ' The store customer must have an opt_in_status'
-            raise
+            new_msg = 'The store customer must have an opt_in_status, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if data['opt_in_status'] not in [True, False]:
             raise TypeError('The opt_in_status must be True or False')
         return self._mc_client._put(url=self._build_path(store_id, 'customers', customer_id), data=data)

--- a/mailchimp3/entities/storeorderlines.py
+++ b/mailchimp3/entities/storeorderlines.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Customers/Instance
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -49,28 +52,28 @@ class StoreOrderLines(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The order line must have an id'
-            raise
+            new_msg = 'The order line must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['product_id']
         except KeyError as error:
-            error.message += ' The order line must have a product_id'
-            raise
+            new_msg = 'The order line must have a product_id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['product_variant_id']
         except KeyError as error:
-            error.message += ' The order line must have a product_variant_id'
-            raise
+            new_msg = 'The order line must have a product_variant_id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['quantity']
         except KeyError as error:
-            error.message += ' The order line must have a quantity'
-            raise
+            new_msg = 'The order line must have a quantity, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['price']
         except KeyError as error:
-            error.message += ' The order line must have a price'
-            raise
+            new_msg = 'The order line must have a price, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(store_id, 'orders', order_id, 'lines'))
         if response is not None:
             self.line_id = response['id']

--- a/mailchimp3/entities/storeorders.py
+++ b/mailchimp3/entities/storeorders.py
@@ -8,6 +8,8 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Customers/Instance
 from __future__ import unicode_literals
 
 import re
+import six
+import sys
 
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storeorderlines import StoreOrderLines
@@ -63,61 +65,61 @@ class StoreOrders(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The order must have an id'
-            raise
+            new_msg = 'The order must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['customer']
         except KeyError as error:
-            error.message += ' The order must have a customer'
-            raise
+            new_msg = 'The order must have a customer, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['customer']['id']
         except KeyError as error:
-            error.message += ' The order customer must have an id'
-            raise
+            new_msg = 'The order customer must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['currency_code']
         except KeyError as error:
-            error.message += ' The order must have a currency_code'
-            raise
+            new_msg = 'The order must have a currency_code, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if not re.match(r"^[A-Z]{3}$", data['currency_code']):
             raise ValueError('The currency_code must be a valid 3-letter ISO 4217 currency code')
         try:
             test = data['order_total']
         except KeyError as error:
-            error.message += ' The order must have an order_total'
-            raise
+            new_msg = 'The order must have an order_total, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['lines']
         except KeyError as error:
-            error.message += ' The order must have at least one order line'
-            raise
+            new_msg = 'The order must have at least one order line, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         for line in data['lines']:
             try:
                 test = line['id']
             except KeyError as error:
-                error.message += ' Each order line must have an id'
-                raise
+                new_msg = 'Each order line must have an id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['product_id']
             except KeyError as error:
-                error.message += ' Each order line must have a product_id'
-                raise
+                new_msg = 'Each order line must have a product_id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['product_variant_id']
             except KeyError as error:
-                error.message += ' Each order line must have a product_variant_id'
-                raise
+                new_msg = 'Each order line must have a product_variant_id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['quantity']
             except KeyError as error:
-                error.message += ' Each order line must have a quantity'
-                raise
+                new_msg = 'Each order line must have a quantity, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = line['price']
             except KeyError as error:
-                error.message += ' Each order line must have a price'
-                raise
+                new_msg = 'Each order line must have a price, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(store_id, 'orders'), data=data)
         if response is not None:
             self.order_id = response['id']

--- a/mailchimp3/entities/storeproducts.py
+++ b/mailchimp3/entities/storeproducts.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Products/Instance.
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storeproductvariants import StoreProductVariants
 
@@ -52,29 +55,29 @@ class StoreProducts(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The product must have an id'
-            raise
+            new_msg = 'The product must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['title']
         except KeyError as error:
-            error.message += ' The product must have a title'
-            raise
+            new_msg = 'The product must have a title, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['variants']
         except KeyError as error:
-            error.message += ' The product must have at least one variant'
-            raise
+            new_msg = 'The product must have at least one variant, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         for variant in data['variants']:
             try:
                 test = variant['id']
             except KeyError as error:
-                error.message += ' Each product variant must have an id'
-                raise
+                new_msg = 'Each product variant must have an id, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
             try:
                 test = variant['title']
             except KeyError as error:
-                error.message += ' Each product variant must have a title'
-                raise
+                new_msg = 'Each product variant must have a title, {}'.format(error)
+                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(store_id, 'products'), data=data)
         if response is not None:
             self.product_id = response['id']

--- a/mailchimp3/entities/storeproductvariants.py
+++ b/mailchimp3/entities/storeproductvariants.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Products/Variants/
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -47,12 +50,13 @@ class StoreProductVariants(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The product variant must have an id'
-            raise
+            new_msg = 'The product variant must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['title']
         except KeyError as error:
-            error.message += ' The product variant must have a title'
+            new_msg = 'The product variant must have a title, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(store_id, 'products', product_id, 'variants'), data=data)
         if response is not None:
             self.variant_id = response['id']
@@ -154,13 +158,13 @@ class StoreProductVariants(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The product variant must have an id'
-            raise
+            new_msg = 'The product variant must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['title']
         except KeyError as error:
-            error.message += ' The product variant must have a title'
-            raise
+            new_msg = 'The product variant must have a title, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         return self._mc_client._put(
             url=self._build_path(store_id, 'products', product_id, 'variants', variant_id),
             data=data

--- a/mailchimp3/entities/stores.py
+++ b/mailchimp3/entities/stores.py
@@ -8,6 +8,8 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Instance.json
 from __future__ import unicode_literals
 
 import re
+import six
+import sys
 
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storecarts import StoreCarts
@@ -55,23 +57,23 @@ class Stores(BaseApi):
         try:
             test = data['id']
         except KeyError as error:
-            error.message += ' The store must have an id'
-            raise
+            new_msg = 'The store must have an id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['list_id']
         except KeyError as error:
-            error.message += ' The store must have a list_id'
-            raise
+            new_msg = 'The store must have a list_id, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The store must have a name'
-            raise
+            new_msg = 'The store must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['currency_code']
         except KeyError as error:
-            error.message += ' The store must have a currency_code'
-            raise
+            new_msg = 'The store must have a currency_code, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         if not re.match(r"^[A-Z]{3}$", data['currency_code']):
             raise ValueError('The currency_code must be a valid 3-letter ISO 4217 currency code')
         response = self._mc_client._post(url=self._build_path(), data=data)

--- a/mailchimp3/entities/templatefolders.py
+++ b/mailchimp3/entities/templatefolders.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/TemplateFolders/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 
 
@@ -36,8 +39,8 @@ class TemplateFolders(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The template folder must have a name'
-            raise
+            new_msg = 'The template folder must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.folder_id = response['id']
@@ -94,8 +97,8 @@ class TemplateFolders(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The template folder must have a name'
-            raise
+            new_msg = 'The template folder must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         self.folder_id = folder_id
         return self._mc_client._patch(url=self._build_path(folder_id), data=data)
 

--- a/mailchimp3/entities/templates.py
+++ b/mailchimp3/entities/templates.py
@@ -7,6 +7,9 @@ Schema: https://api.mailchimp.com/schema/3.0/Templates/Instance.json
 """
 from __future__ import unicode_literals
 
+import six
+import sys
+
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.templatedefaultcontent import TemplateDefaultContent
 
@@ -41,13 +44,13 @@ class Templates(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The template must have a name'
-            raise
+            new_msg = 'The template must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['html']
         except KeyError as error:
-            error.message += ' The template must have html'
-            raise
+            new_msg = 'The template must have html, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.template_id = response['id']
@@ -110,13 +113,13 @@ class Templates(BaseApi):
         try:
             test = data['name']
         except KeyError as error:
-            error.message += ' The template must have a name'
-            raise
+            new_msg = 'The template must have a name, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         try:
             test = data['html']
         except KeyError as error:
-            error.message += ' The template must have html'
-            raise
+            new_msg = 'The template must have html, {}'.format(error)
+            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         self.template_id = template_id
         return self._mc_client._patch(url=self._build_path(template_id), data=data)
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     ],
     keywords='mailchimp api v3 client wrapper',
     packages=find_packages(),
-    install_requires=['requests'],
+    install_requires=['requests', 'six'],
     # test_suite='tests',
 )


### PR DESCRIPTION
Correct the way exceptions were working to be valid for both python 2 and 3, see issue #61 