### PR TITLE
Fix incorrect endpoint url for lists.update_members

### DIFF
--- a/mailchimp3/entities/lists.py
+++ b/mailchimp3/entities/lists.py
@@ -216,7 +216,7 @@ class Lists(BaseApi):
             test = data['update_existing']
         except KeyError:
             data['update_existing'] = False
-        return self._mc_client._post(url=self._build_path(), data=data)
+        return self._mc_client._post(url=self._build_path(list_id), data=data)
 
 
     def all(self, get_all=False, **queryparams):


### PR DESCRIPTION
- Add list_id to end of url

Fixes Issue #66 