### PR TITLE
Update data checks to use if

### DIFF
--- a/mailchimp3/entities/authorizedapps.py
+++ b/mailchimp3/entities/authorizedapps.py
@@ -7,9 +7,6 @@ Schema: http://api.mailchimp.com/schema/3.0/AuthorizedApps/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -40,16 +37,10 @@ class AuthorizedApps(BaseApi):
         }
         """
         self.app_id = None
-        try:
-            test = data['client_id']
-        except KeyError as error:
-            new_msg = 'The authorized app must have a client_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['client_secret']
-        except KeyError as error:
-            new_msg = 'The authorized app must have a client_secret, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'client_id' not in data:
+            raise KeyError('The authorized app must have a client_id')
+        if 'client_secret' not in data:
+            raise KeyError('The authorized app must have a client_secret')
         return self._mc_client._post(url=self._build_path(), data=data)
 
 

--- a/mailchimp3/entities/automationemailqueues.py
+++ b/mailchimp3/entities/automationemailqueues.py
@@ -9,9 +9,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Automations/Emails/Queue/Instance.j
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email, check_subscriber_hash
 
@@ -50,11 +47,8 @@ class AutomationEmailQueues(BaseApi):
         """
         self.workflow_id = workflow_id
         self.email_id = email_id
-        try:
-            test = data['email_address']
-        except KeyError as error:
-            new_msg = 'The automation email queue must have an email_address, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'email_address' not in data:
+            raise KeyError('The automation email queue must have an email_address')
         check_email(data['email_address'])
         response = self._mc_client._post(
             url=self._build_path(workflow_id, 'emails', email_id, 'actions/pause-all-emails'),

--- a/mailchimp3/entities/automationremovedsubscribers.py
+++ b/mailchimp3/entities/automationremovedsubscribers.py
@@ -9,9 +9,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Automations/RemovedSubscribers/Inst
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email
 
@@ -45,11 +42,8 @@ class AutomationRemovedSubscribers(BaseApi):
         }
         """
         self.workflow_id = workflow_id
-        try:
-            test = data['email_address']
-        except KeyError as error:
-            new_msg = 'The automation removed subscriber must have an email_address, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'email_address' not in data:
+            raise KeyError('The automation removed subscriber must have an email_address')
         check_email(data['email_address'])
         return self._mc_client._post(url=self._build_path(workflow_id, 'removed-subscribers'), data=data)
 

--- a/mailchimp3/entities/batches.py
+++ b/mailchimp3/entities/batches.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Batches/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -43,25 +40,16 @@ class Batches(BaseApi):
             ]
         }
         """
-        try:
-            test = data['operations']
-        except KeyError as error:
-            new_msg = 'The batch must have operations, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'operations' not in data:
+            raise KeyError('The batch must have operations')
         for op in data['operations']:
-            try:
-                test = op['method']
-            except KeyError as error:
-                new_msg = 'The batch operation must have a method, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'method' not in op:
+                raise KeyError('The batch operation must have a method')
             if op['method'] not in ['GET', 'POST', 'PUT', 'PATCH']:
                 raise ValueError('The batch operation method must be one of "GET", "POST", "PUT", or "PATCH", not {0}'
                                  ''.format(op['method']))
-            try:
-                test = op['path']
-            except KeyError as error:
-                new_msg = 'The batch operation must have a path, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'path' not in op:
+                raise KeyError('The batch operation must have a path')
         return self._mc_client._post(url=self._build_path(), data=data)
 
 

--- a/mailchimp3/entities/campaignfeedback.py
+++ b/mailchimp3/entities/campaignfeedback.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Campaigns/Feedback/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -44,11 +41,8 @@ class CampaignFeedback(BaseApi):
         queryparams['exclude_fields'] = []
         """
         self.campaign_id = campaign_id
-        try:
-            test = data['message']
-        except KeyError as error:
-            new_msg = 'The campaign feedback must have a message, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'message' not in data:
+            raise KeyError('The campaign feedback must have a message')
         response = self._mc_client._post(url=self._build_path(campaign_id, 'feedback'), data=data, **queryparams)
         if response is not None:
             self.feedback_id = response['feedback_id']
@@ -111,11 +105,8 @@ class CampaignFeedback(BaseApi):
         """
         self.campaign_id = campaign_id
         self.feedback_id = feedback_id
-        try:
-            test = data['message']
-        except KeyError as error:
-            new_msg = 'The campaign feedback must have a message, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'message' not in data:
+            raise KeyError('The campaign feedback must have a message')
         return self._mc_client._patch(url=self._build_path(campaign_id, 'feedback', feedback_id), data=data)
 
 

--- a/mailchimp3/entities/campaignfolders.py
+++ b/mailchimp3/entities/campaignfolders.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/CampaignFolders/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -36,11 +33,8 @@ class CampaignFolders(BaseApi):
             "name": string*
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The campaign folder must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The campaign folder must have a name')
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.folder_id = response['id']
@@ -95,11 +89,8 @@ class CampaignFolders(BaseApi):
         }
         """
         self.folder_id = folder_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The campaign folder must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The campaign folder must have a name')
         return self._mc_client._patch(url=self._build_path(folder_id), data=data)
 
 

--- a/mailchimp3/entities/campaigns.py
+++ b/mailchimp3/entities/campaigns.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Campaigns/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.campaignactions import CampaignActions
 from mailchimp3.entities.campaigncontent import CampaignContent
@@ -69,54 +66,36 @@ class Campaigns(BaseApi):
             "type": string* (Must be one of "regular", "plaintext", "rss", "variate", or "absplit")
         }
         """
-        try:
-            test = data['recipients']
-        except KeyError as error:
-            new_msg = 'The campaign must have recipients, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['recipients']['list_id']
-        except KeyError as error:
-            new_msg = 'The campaign recipients must have a list_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['settings']['subject_line']
-        except KeyError as error:
-            new_msg = 'The campaign settings must have a subject_line, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['settings']['from_name']
-        except KeyError as error:
-            new_msg = 'The campaign settings must have a from_name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['settings']['reply_to']
-        except KeyError as error:
-            new_msg = 'The campaign settings must have a reply_to, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'recipients' not in data:
+            raise KeyError('The campaign must have recipients')
+        if 'list_id' not in data['recipients']:
+            raise KeyError('The campaign recipients must have a list_id')
+        if 'settings' not in data:
+            raise KeyError('The campaign must have settings')
+        if 'subject_line' not in data['settings']:
+            raise KeyError('The campaign settings must have a subject_line')
+        if 'from_name' not in data['settings']:
+            raise KeyError('The campaign settings must have a from_name')
+        if 'reply_to' not in data['settings']:
+            raise KeyError('The campaign settings must have a reply_to')
         check_email(data['settings']['reply_to'])
-        try:
-            test = data['type']
-        except KeyError as error:
-            new_msg = 'The campaign must have a type, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'type' not in data:
+            raise KeyError('The campaign must have a type')
         if not data['type'] in ['regular', 'plaintext', 'rss', 'variate', 'abspilt']:
             raise ValueError('The campaign type must be one of "regular", "plaintext", "rss", or "variate"')
         if data['type'] == 'variate':
-            try:
-                test = data['variate_settings']['winner_criteria']
-            except KeyError as error:
-                new_msg = 'The campaign variate_settings must have a winner_criteria, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'variate_settings' not in data:
+                raise KeyError('The variate campaign must have variate_settings')
+            if 'winner_criteria' not in data['variate_settings']:
+                raise KeyError('The campaign variate_settings must have a winner_criteria')
             if data['variate_settings']['winner_criteria'] not in ['opens', 'clicks', 'total_revenue', 'manual']:
                 raise ValueError('The campaign variate_settings '
                                  'winner_criteria must be one of "opens", "clicks", "total_revenue", or "manual"')
         if data['type'] == 'rss':
-            try:
-                test = data['rss_opts']['feed_url']
-            except KeyError as error:
-                new_msg = 'The campaign rss_opts must have a feed_url, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'rss_opts' not in data:
+                raise KeyError('The rss campaign must have rss_opts')
+            if 'feed_url' not in data['rss_opts']:
+                raise KeyError('The campaign rss_opts must have a feed_url')
             if not data['rss_opts']['frequency'] in ['daily', 'weekly', 'monthly']:
                 raise ValueError('The rss_opts frequency must be one of "daily", "weekly", or "monthly"')
         response = self._mc_client._post(url=self._build_path(), data=data)
@@ -186,26 +165,14 @@ class Campaigns(BaseApi):
         }
         """
         self.campaign_id = campaign_id
-        try:
-            test = data['settings']
-        except KeyError as error:
-            new_msg = 'The campaign must have settings, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['settings']['subject_line']
-        except KeyError as error:
-            new_msg = 'The campaign settings must have a subject_line, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['settings']['from_name']
-        except KeyError as error:
-            new_msg = 'The campaign settings must have a from_name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['settings']['reply_to']
-        except KeyError as error:
-            new_msg = 'The campaign settings must have a reply_to, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'settings' not in data:
+            raise KeyError('The campaign must have settings')
+        if 'subject_line' not in data['settings']:
+            raise KeyError('The campaign settings must have a subject_line')
+        if 'from_name' not in data['settings']:
+            raise KeyError('The campaign settings must have a from_name')
+        if 'reply_to' not in data['setting']:
+            raise KeyError('The campaign settings must have a reply_to')
         check_email(data['settings']['reply_to'])
         return self._mc_client._patch(url=self._build_path(campaign_id), data=data)
 

--- a/mailchimp3/entities/conversationmessages.py
+++ b/mailchimp3/entities/conversationmessages.py
@@ -9,9 +9,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Conversations/Messages/Instance.jso
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email
 
@@ -45,17 +42,11 @@ class ConversationMessages(BaseApi):
         }
         """
         self.conversation_id = conversation_id
-        try:
-            test = data['from_email']
-        except KeyError as error:
-            new_msg = 'The conversation message must have a from_email, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'from_email' not in data:
+            raise KeyError('The conversation message must have a from_email')
         check_email(data['from_email'])
-        try:
-            test = data['read']
-        except KeyError as error:
-            new_msg = 'The conversation message must have a read, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'read' not in data:
+            raise KeyError('The conversation message must have a read')
         if data['read'] not in [True, False]:
             raise TypeError('The conversation message read must be True or False')
         response =  self._mc_client._post(url=self._build_path(conversation_id, 'messages'), data=data)

--- a/mailchimp3/entities/filemanagerfiles.py
+++ b/mailchimp3/entities/filemanagerfiles.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/FileManager/Files/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -39,16 +36,10 @@ class FileManagerFiles(BaseApi):
             "file_data": string*
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The file must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['file_data']
-        except KeyError as error:
-            new_msg = 'The file must have file_data, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The file must have a name')
+        if 'file_data' not in data:
+            raise KeyError('The file must have file_data')
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.file_id = response['id']
@@ -110,16 +101,10 @@ class FileManagerFiles(BaseApi):
         }
         """
         self.file_id = file_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The file must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['file_data']
-        except KeyError as error:
-            new_msg = 'The file must have file_data, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The file must have a name')
+        if 'file_data' not in data:
+            raise KeyError('The file must have file_data')
         return self._mc_client._patch(url=self._build_path(file_id), data=data)
 
 

--- a/mailchimp3/entities/filemanagerfolders.py
+++ b/mailchimp3/entities/filemanagerfolders.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/FileManager/Folders/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -38,11 +35,8 @@ class FileManagerFolders(BaseApi):
             "name": string*
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The folder must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The folder must have a name')
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.folder_id = response['id']
@@ -100,11 +94,8 @@ class FileManagerFolders(BaseApi):
         }
         """
         self.folder_id = folder_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The folder must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The folder must have a name')
         return self._mc_client._patch(url=self._build_path(folder_id), data=data)
 
 

--- a/mailchimp3/entities/listinterestcategories.py
+++ b/mailchimp3/entities/listinterestcategories.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.j
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listinterestcategoryinterest import ListInterestCategoryInterest
 
@@ -46,16 +43,10 @@ class ListInterestCategories(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            test = data['title']
-        except KeyError as error:
-            new_msg = 'The list interest category must have a title, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['type']
-        except KeyError as error:
-            new_msg = 'The list interest category must have a type, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'title' not in data:
+            raise KeyError('The list interest category must have a title')
+        if 'type' not in data:
+            raise KeyError('The list interest category must have a type')
         if data['type'] not in ['checkboxes', 'dropdown', 'radio', 'hidden']:
             raise ValueError('The list interest category type must be one of "checkboxes", "dropdown", "radio", or '
                              '"hidden"')
@@ -124,16 +115,10 @@ class ListInterestCategories(BaseApi):
         """
         self.list_id = list_id
         self.category_id = category_id
-        try:
-            test = data['title']
-        except KeyError as error:
-            new_msg = 'The list interest category must have a title, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['type']
-        except KeyError as error:
-            new_msg = 'The list interest category must have a type, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'title' not in data:
+            raise KeyError('The list interest category must have a title')
+        if 'type' not in data:
+            raise KeyError('The list interest category must have a type')
         if data['type'] not in ['checkboxes', 'dropdown', 'radio', 'hidden']:
             raise ValueError('The list interest category type must be one of "checkboxes", "dropdown", "radio", or '
                              '"hidden"')

--- a/mailchimp3/entities/listinterestcategoryinterest.py
+++ b/mailchimp3/entities/listinterestcategoryinterest.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -50,11 +47,8 @@ class ListInterestCategoryInterest(BaseApi):
         """
         self.list_id = list_id
         self.category_id = category_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list interest category interest must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list interest category interest must have a name')
         response =  self._mc_client._post(
             url=self._build_path(list_id, 'interest-categories', category_id, 'interests'),
             data=data
@@ -136,11 +130,8 @@ class ListInterestCategoryInterest(BaseApi):
         self.list_id = list_id
         self.category_id = category_id
         self.interest_id = interest_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list interest category interest must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list interest category interest must have a name')
         return self._mc_client._patch(
             url=self._build_path(list_id, 'interest-categories', category_id, 'interests', interest_id),
             data=data

--- a/mailchimp3/entities/listmembernotes.py
+++ b/mailchimp3/entities/listmembernotes.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Members/Notes/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_subscriber_hash
 
@@ -51,11 +48,8 @@ class ListMemberNotes(BaseApi):
         subscriber_hash = check_subscriber_hash(subscriber_hash)
         self.list_id = list_id
         self.subscriber_hash = subscriber_hash
-        try:
-            test = data['note']
-        except KeyError as error:
-            new_msg = 'The list member note must have a note, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'note' not in data:
+            raise KeyError('The list member note must have a note')
         response = self._mc_client._post(url=self._build_path(list_id, 'members', subscriber_hash, 'notes'), data=data)
         if response is not None:
             self.note_id = response['id']
@@ -141,11 +135,8 @@ class ListMemberNotes(BaseApi):
         self.list_id = list_id
         self.subscriber_hash = subscriber_hash
         self.note_id = note_id
-        try:
-            test = data['note']
-        except KeyError as error:
-            new_msg = 'The list member note must have a note, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'note' not in data:
+            raise KeyError('The list member note must have a note')
         return self._mc_client._patch(
             url=self._build_path(list_id, 'members', subscriber_hash, 'notes', note_id),
             data=data

--- a/mailchimp3/entities/listmembers.py
+++ b/mailchimp3/entities/listmembers.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Members/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listmemberactivity import ListMemberActivity
 from mailchimp3.entities.listmembergoals import ListMemberGoals
@@ -49,19 +46,13 @@ class ListMembers(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            test = data['status']
-        except KeyError as error:
-            new_msg = 'The list member must have a status, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'status' not in data:
+            raise KeyError('The list member must have a status')
         if data['status'] not in ['subscribed', 'unsubscribed', 'cleaned', 'pending']:
             raise ValueError('The list member status must be one of "subscribed", "unsubscribed", "cleaned", or '
                              '"pending"')
-        try:
-            test = data['email_address']
-        except KeyError as error:
-            new_msg = 'The list member must have an email_address, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'email_address' not in data:
+            raise KeyError('The list member must have an email_address')
         check_email(data['email_address'])
         response = self._mc_client._post(url=self._build_path(list_id, 'members'), data=data)
         if response is not None:
@@ -161,17 +152,11 @@ class ListMembers(BaseApi):
         subscriber_hash = check_subscriber_hash(subscriber_hash)
         self.list_id = list_id
         self.subscriber_hash = subscriber_hash
-        try:
-            test = data['email_address']
-        except KeyError as error:
-            new_msg = 'The list member must have an email_address, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'email_address' not in data:
+            raise KeyError('The list member must have an email_address')
         check_email(data['email_address'])
-        try:
-            test = data['status_if_new']
-        except KeyError as error:
-            new_msg = 'The list member must have a status_if_new, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'status_if_new' not in data:
+            raise KeyError('The list member must have a status_if_new')
         if data['status_if_new'] not in ['subscribed', 'unsubscribed', 'cleaned', 'pending']:
             raise ValueError('The list member status_if_new must be one of "subscribed", "unsubscribed", "cleaned", '
                              'or "pending"')

--- a/mailchimp3/entities/listmergefields.py
+++ b/mailchimp3/entities/listmergefields.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/MergeFields/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -41,16 +38,10 @@ class ListMergeFields(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list merge field must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['type']
-        except KeyError as error:
-            new_msg = 'The list merge field must have a type, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list merge field must have a name')
+        if 'type' not in data:
+            raise KeyError('The list merge field must have a type')
         response = self._mc_client._post(url=self._build_path(list_id, 'merge-fields'), data=data)
         if response is not None:
             self.merge_id = response['id']
@@ -113,11 +104,8 @@ class ListMergeFields(BaseApi):
         """
         self.list_id = list_id
         self.merge_id = merge_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list merge field must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list merge field must have a name')
         return self._mc_client._patch(url=self._build_path(list_id, 'merge-fields', merge_id), data=data)
 
 

--- a/mailchimp3/entities/lists.py
+++ b/mailchimp3/entities/lists.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listabusereports import ListAbuseReports
 from mailchimp3.entities.listactivity import ListActivity
@@ -77,82 +74,37 @@ class Lists(BaseApi):
             "email_type_option": boolean
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']
-        except KeyError as error:
-            new_msg = 'The list must have a contact, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['company']
-        except KeyError as error:
-            new_msg = 'The list contact must have a company, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['address1']
-        except KeyError as error:
-            new_msg = 'The list contact must have a address1, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['city']
-        except KeyError as error:
-            new_msg = 'The list contact must have a city, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['state']
-        except KeyError as error:
-            new_msg = 'The list contact must have a state, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['zip']
-        except KeyError as error:
-            new_msg = 'The list contact must have a zip, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['country']
-        except KeyError as error:
-            new_msg = 'The list contact must have a country, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['permission_reminder']
-        except KeyError as error:
-            new_msg = 'The list must have a permission_reminder, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']
-        except KeyError as error:
-            new_msg = 'The list must have a campaign_defaults, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']['from_name']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a from_name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']['from_email']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a from_email, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list must have a name')
+        if 'contact' not in data:
+            raise KeyError('The list must have a contact')
+        if 'company' not in data['contact']:
+            raise KeyError('The list contact must have a company')
+        if 'address1' not in data['contact']:
+            raise KeyError('The list contact must have a address1')
+        if 'city' not in data['contact']:
+            raise KeyError('The list contact must have a city')
+        if 'state' not in data['contact']:
+            raise KeyError('The list contact must have a state')
+        if 'zip' not in data['contact']:
+            raise KeyError('The list contact must have a zip')
+        if 'country' not in data['contact']:
+            raise KeyError('The list contact must have a country')
+        if 'permission_reminder' not in data:
+            raise KeyError('The list must have a permission_reminder')
+        if 'campaign_defaults' not in data:
+            raise KeyError('The list must have a campaign_defaults')
+        if 'from_name' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a from_name')
+        if 'from_email' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a from_email')
         check_email(data['campaign_defaults']['from_email'])
-        try:
-            test = data['campaign_defaults']['subject']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a subject, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']['language']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a language, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['email_type_option']
-        except KeyError as error:
-            new_msg = 'The list must have an email_type_option, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'subject' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a subject')
+        if 'language' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a language')
+        if 'email_type_option' not in data:
+            raise KeyError('The list must have an email_type_option')
         if data['email_type_option'] not in [True, False]:
             raise TypeError('The list email_type_option must be True or False')
         response = self._mc_client._post(url=self._build_path(), data=data)
@@ -167,8 +119,8 @@ class Lists(BaseApi):
         """
         Batch subscribe or unsubscribe list members.
 
-        Only the members array is required in the request body parameters. 
-        Within the members array, each member requires an email_address 
+        Only the members array is required in the request body parameters.
+        Within the members array, each member requires an email_address
         and either a status or status_if_new. The update_existing parameter
         will also be considered required to help prevent accidental updates
         to existing members and will default to false if not present.
@@ -190,19 +142,14 @@ class Lists(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            test = data['members']
-            if not len(test) <= 500:
+        if 'members' not in data:
+            raise KeyError('The update must have at least one member')
+        else:
+            if not len(data['members']) <= 500:
                 raise ValueError('You may only batch sub/unsub 500 members at a time')
-        except KeyError as error:
-            new_msg = 'The update must have at least one member, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
         for member in data['members']:
-            try:
-                test = member['email_address']
-            except KeyError as error:
-                new_msg = 'Each list member must have an email_address, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'email_address' not in member:
+                raise KeyError('Each list member must have an email_address')
             check_email(member['email_address'])
             if 'status' not in member and 'status_if_new' not in member:
                 raise KeyError('Each list member must have either a status or a status_if_new')
@@ -213,9 +160,7 @@ class Lists(BaseApi):
             if 'status_if_new' in member and member['status_if_new'] not in valid_statuses:
                 raise ValueError('The list member status_if_new must be one of "subscribed", "unsubscribed", '
                                  '"cleaned", or "pending"')
-        try:
-            test = data['update_existing']
-        except KeyError:
+        if 'update_existing' not in data:
             data['update_existing'] = False
         return self._mc_client._post(url=self._build_path(list_id), data=data)
 
@@ -291,82 +236,37 @@ class Lists(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']
-        except KeyError as error:
-            new_msg = 'The list must have a contact, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['company']
-        except KeyError as error:
-            new_msg = 'The list contact must have a company, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['address1']
-        except KeyError as error:
-            new_msg = 'The list contact must have a address1, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['city']
-        except KeyError as error:
-            new_msg = 'The list contact must have a city, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['state']
-        except KeyError as error:
-            new_msg = 'The list contact must have a state, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['zip']
-        except KeyError as error:
-            new_msg = 'The list contact must have a zip, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['contact']['country']
-        except KeyError as error:
-            new_msg = 'The list contact must have a country, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['permission_reminder']
-        except KeyError as error:
-            new_msg = 'The list must have a permission_reminder, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']
-        except KeyError as error:
-            new_msg = 'The list must have a campaign_defaults, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']['from_name']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a from_name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']['from_email']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a from_email, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list must have a name')
+        if 'contact' not in data:
+            raise KeyError('The list must have a contact')
+        if 'company' not in data['contact']:
+            raise KeyError('The list contact must have a company')
+        if 'address1' not in data['contact']:
+            raise KeyError('The list contact must have a address1')
+        if 'city' not in data['contact']:
+            raise KeyError('The list contact must have a city')
+        if 'state' not in data['contact']:
+            raise KeyError('The list contact must have a state')
+        if 'zip' not in data['contact']:
+            raise KeyError('The list contact must have a zip')
+        if 'country' not in data['contact']:
+            raise KeyError('The list contact must have a country')
+        if 'permission_reminder' not in data:
+            raise KeyError('The list must have a permission_reminder')
+        if 'campaign_defaults' not in data:
+            raise KeyError('The list must have a campaign_defaults')
+        if 'from_name' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a from_name')
+        if 'from_email' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a from_email')
         check_email(data['campaign_defaults']['from_email'])
-        try:
-            test = data['campaign_defaults']['subject']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a subject, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['campaign_defaults']['language']
-        except KeyError as error:
-            new_msg = 'The list campaign_defaults must have a language, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['email_type_option']
-        except KeyError as error:
-            new_msg = 'The list must have an email_type_option, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'subject' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a subject')
+        if 'language' not in data['campaign_defaults']:
+            raise KeyError('The list campaign_defaults must have a language')
+        if 'email_type_option' not in data:
+            raise KeyError('The list must have an email_type_option')
         if data['email_type_option'] not in [True, False]:
             raise TypeError('The list email_type_option must be True or False')
         return self._mc_client._patch(url=self._build_path(list_id), data=data)

--- a/mailchimp3/entities/listsegmentmembers.py
+++ b/mailchimp3/entities/listsegmentmembers.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Members/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email, check_subscriber_hash
 
@@ -51,17 +48,11 @@ class ListSegmentMembers(BaseApi):
         """
         self.list_id = list_id
         self.segment_id = segment_id
-        try:
-            test = data['email_address']
-        except KeyError as error:
-            new_msg = 'The list segment member must have an email_address, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'email_address' not in data:
+            raise KeyError('The list segment member must have an email_address')
         check_email(data['email_address'])
-        try:
-            test = data['status']
-        except KeyError as error:
-            new_msg = 'The list segment member must have a status, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'status' not in data:
+            raise KeyError('The list segment member must have a status')
         if data['status'] not in ['subscribed', 'unsubscribed', 'cleaned', 'pending']:
             raise ValueError('The list segment member status must be one of "subscribed", "unsubscribed", "cleaned" or'
                              '"pending"')

--- a/mailchimp3/entities/listsegments.py
+++ b/mailchimp3/entities/listsegments.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Segments/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.listsegmentmembers import ListSegmentMembers
 
@@ -44,11 +41,8 @@ class ListSegments(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list segment must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list segment must have a name')
         response = self._mc_client._post(url=self._build_path(list_id, 'segments'), data=data)
         if response is not None:
             self.segment_id = response['id']
@@ -117,11 +111,8 @@ class ListSegments(BaseApi):
         """
         self.list_id = list_id
         self.segment_id = segment_id
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The list segment must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The list segment must have a name')
         return self._mc_client._patch(url=self._build_path(list_id, 'segments', segment_id), data=data)
 
 

--- a/mailchimp3/entities/listtwitterleadgenerationcards.py
+++ b/mailchimp3/entities/listtwitterleadgenerationcards.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/TwitterLeadGenCards/Instance.
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_url
 
@@ -46,40 +43,22 @@ class ListTwitterLeadGenerationCards(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            data['name']
-        except KeyError as error:
-            new_msg = 'The twitter lead generation card must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            data['title']
-        except KeyError as error:
-            new_msg = 'The twitter lead generation card must have a title, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            data['cta_text']
-        except KeyError as error:
-            new_msg = 'The twitter lead generation card must have a cta_text, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The twitter lead generation card must have a name')
+        if 'title' not in data:
+            raise KeyError('The twitter lead generation card must have a title')
+        if 'cta_text' not in data:
+            raise KeyError('The twitter lead generation card must have a cta_text')
         if len(data['cta_text']) > 20:
             raise ValueError('The twitter lead generation card cta_text must be 20 characters or less')
-        try:
-            data['privacy_policy_url']
-        except KeyError as error:
-            new_msg = 'The twitter lead generation card must have a privacy_policy_url, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'privacy_policy_url' not in data:
+            raise KeyError('The twitter lead generation card must have a privacy_policy_url')
         check_url(data['privacy_policy_url'])
-        try:
-            data['image_url']
-        except KeyError as error:
-            new_msg = 'The twitter lead generation card must have a image_url, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'image_url' not in data:
+            raise KeyError('The twitter lead generation card must have a image_url')
         check_url(data['image_url'])
-        try:
-            data['twitter_account_id']
-        except KeyError as error:
-            new_msg = 'The twitter lead generation card must have a twitter_account_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'twitter_account_id' not in data:
+            raise KeyError('The twitter lead generation card must have a twitter_account_id')
         response = self._mc_client._post(url=self._build_path(list_id, 'twitter-lead-gen-cards'), data=data)
         if response is not None:
             self.twitter_card_id = response['id']

--- a/mailchimp3/entities/listwebhooks.py
+++ b/mailchimp3/entities/listwebhooks.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Lists/Webhooks/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_url
 
@@ -46,11 +43,8 @@ class ListWebhooks(BaseApi):
         }
         """
         self.list_id = list_id
-        try:
-            test = data['url']
-        except KeyError as error:
-            new_msg = 'The list webhook must have a url, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'url' not in data:
+            raise KeyError('The list webhook must have a url')
         check_url(data['url'])
         response = self._mc_client._post(url=self._build_path(list_id, 'webhooks'), data=data)
         if response is not None:

--- a/mailchimp3/entities/searchmembers.py
+++ b/mailchimp3/entities/searchmembers.py
@@ -38,8 +38,8 @@ class SearchMembers(BaseApi):
         queryparams['list_id'] = string
         queryparams['offset'] = integer
         """
-        try:
+        if 'list_id' in queryparams:
             self.list_id = queryparams['list_id']
-        except KeyError:
+        else:
             self.list_id = None
         return self._mc_client._get(url=self._build_path(), **queryparams)

--- a/mailchimp3/entities/storecartlines.py
+++ b/mailchimp3/entities/storecartlines.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Carts/Lines/Instan
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -49,31 +46,16 @@ class StoreCartLines(BaseApi):
         """
         self.store_id = store_id
         self.cart_id = cart_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The cart line must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['product_id']
-        except KeyError as error:
-            new_msg = 'The cart line must have a product_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['product_variant_id']
-        except KeyError as error:
-            new_msg = 'The cart line must have a product_variant_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['quantity']
-        except KeyError as error:
-            new_msg = 'The cart line must have a quantity, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['price']
-        except KeyError as error:
-            new_msg = 'The cart line must have a price, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The cart line must have an id')
+        if 'product_id' not in data:
+            raise KeyError('The cart line must have a product_id')
+        if 'product_variant_id' not in data:
+            raise KeyError('The cart line must have a product_variant_id')
+        if 'quantity' not in data:
+            raise KeyError('The cart line must have a quantity')
+        if 'price' not in data:
+            raise KeyError('The cart line must have a price')
         response = self._mc_client._post(url=self._build_path(store_id, 'carts', cart_id, 'lines'), data=data)
         if response is not None:
             self.line_id = response['id']

--- a/mailchimp3/entities/storecarts.py
+++ b/mailchimp3/entities/storecarts.py
@@ -8,8 +8,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Carts/Instance.jso
 from __future__ import unicode_literals
 
 import re
-import six
-import sys
 
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storecartlines import StoreCartLines
@@ -61,64 +59,31 @@ class StoreCarts(BaseApi):
         }
         """
         self.store_id = store_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The cart must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['customer']
-        except KeyError as error:
-            new_msg = 'The cart must have a customer, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['customer']['id']
-        except KeyError as error:
-            new_msg = 'The cart customer must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['currency_code']
-        except KeyError as error:
-            new_msg = 'The cart must have a currency_code, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The cart must have an id')
+        if 'customer' not in data:
+            raise KeyError('The cart must have a customer')
+        if 'id' not in data['customer']:
+            raise KeyError('The cart customer must have an id')
+        if 'currency_code' not in data:
+            raise KeyError('The cart must have a currency_code')
         if not re.match(r"^[A-Z]{3}$", data['currency_code']):
             raise ValueError('The currency_code must be a valid 3-letter ISO 4217 currency code')
-        try:
-            test = data['order_total']
-        except KeyError as error:
-            new_msg = 'The cart must have an order_total, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['lines']
-        except KeyError as error:
-            new_msg = 'The cart must have at least one cart line, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'order_total' not in data:
+            raise KeyError('The cart must have an order_total')
+        if 'lines' not in data:
+            raise KeyError('The cart must have at least one cart line')
         for line in data['lines']:
-            try:
-                test = line['id']
-            except KeyError as error:
-                new_msg = 'Each cart line must have an id, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['product_id']
-            except KeyError as error:
-                new_msg = 'Each cart line must have a product_id, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['product_variant_id']
-            except KeyError as error:
-                new_msg = 'Each cart line must have a product_variant_id, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['quantity']
-            except KeyError as error:
-                new_msg = 'Each cart line must have a quantity, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['price']
-            except KeyError as error:
-                new_msg = 'Each cart line must have a price, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'id' not in line:
+                raise KeyError('Each cart line must have an id')
+            if 'product_id' not in line:
+                raise KeyError('Each cart line must have a product_id')
+            if 'product_variant_id' not in line:
+                raise KeyError('Each cart line must have a product_variant_id')
+            if 'quantity' not in line:
+                raise KeyError('Each cart line must have a quantity')
+            if 'price' not in line:
+                raise KeyError('Each cart line must have a price')
         response = self._mc_client._post(url=self._build_path(store_id, 'carts'), data=data)
         if response is not None:
             self.cart_id = response['id']

--- a/mailchimp3/entities/storecustomers.py
+++ b/mailchimp3/entities/storecustomers.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Customers/Instance
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.helpers import check_email
 
@@ -46,22 +43,13 @@ class StoreCustomers(BaseApi):
         }
         """
         self.store_id = store_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The store customer must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['email_address']
-        except KeyError as error:
-            new_msg = 'The store customer must have an email_address, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The store customer must have an id')
+        if 'email_address' not in data:
+            raise KeyError('The store customer must have an email_address')
         check_email(data['email_address'])
-        try:
-            test = data['opt_in_status']
-        except KeyError as error:
-            new_msg = 'The store customer must have an opt_in_status, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'opt_in_status' not in data:
+            raise KeyError('The store customer must have an opt_in_status')
         if data['opt_in_status'] not in [True, False]:
             raise TypeError('The opt_in_status must be True or False')
         response = self._mc_client._post(url=self._build_path(store_id, 'customers'), data=data)
@@ -146,22 +134,13 @@ class StoreCustomers(BaseApi):
         """
         self.store_id = store_id
         self.customer_id = customer_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The store customer must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['email_address']
-        except KeyError as error:
-            new_msg = 'Each store customer must have an email_address, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The store customer must have an id')
+        if 'email_address' not in data:
+            raise KeyError('Each store customer must have an email_address')
         check_email(data['email_address'])
-        try:
-            test = data['opt_in_status']
-        except KeyError as error:
-            new_msg = 'The store customer must have an opt_in_status, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'opt_in_status' not in data:
+            raise KeyError('The store customer must have an opt_in_status')
         if data['opt_in_status'] not in [True, False]:
             raise TypeError('The opt_in_status must be True or False')
         return self._mc_client._put(url=self._build_path(store_id, 'customers', customer_id), data=data)

--- a/mailchimp3/entities/storeorderlines.py
+++ b/mailchimp3/entities/storeorderlines.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Customers/Instance
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -49,31 +46,16 @@ class StoreOrderLines(BaseApi):
         """
         self.store_id = store_id
         self.order_id = order_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The order line must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['product_id']
-        except KeyError as error:
-            new_msg = 'The order line must have a product_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['product_variant_id']
-        except KeyError as error:
-            new_msg = 'The order line must have a product_variant_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['quantity']
-        except KeyError as error:
-            new_msg = 'The order line must have a quantity, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['price']
-        except KeyError as error:
-            new_msg = 'The order line must have a price, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The order line must have an id')
+        if 'product_id' not in data:
+            raise KeyError('The order line must have a product_id')
+        if 'product_variant_id' not in data:
+            raise KeyError('The order line must have a product_variant_id')
+        if 'quantity' not in data:
+            raise KeyError('The order line must have a quantity')
+        if 'price' not in data:
+            raise KeyError('The order line must have a price')
         response = self._mc_client._post(url=self._build_path(store_id, 'orders', order_id, 'lines'))
         if response is not None:
             self.line_id = response['id']

--- a/mailchimp3/entities/storeorders.py
+++ b/mailchimp3/entities/storeorders.py
@@ -8,8 +8,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Customers/Instance
 from __future__ import unicode_literals
 
 import re
-import six
-import sys
 
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storeorderlines import StoreOrderLines
@@ -62,64 +60,31 @@ class StoreOrders(BaseApi):
         }
         """
         self.store_id = store_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The order must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['customer']
-        except KeyError as error:
-            new_msg = 'The order must have a customer, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['customer']['id']
-        except KeyError as error:
-            new_msg = 'The order customer must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['currency_code']
-        except KeyError as error:
-            new_msg = 'The order must have a currency_code, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The order must have an id')
+        if 'customer' not in data:
+            raise KeyError('The order must have a customer')
+        if 'id' not in data['customer']:
+            raise KeyError('The order customer must have an id')
+        if 'currency_code' not in data:
+            raise KeyError('The order must have a currency_code')
         if not re.match(r"^[A-Z]{3}$", data['currency_code']):
             raise ValueError('The currency_code must be a valid 3-letter ISO 4217 currency code')
-        try:
-            test = data['order_total']
-        except KeyError as error:
-            new_msg = 'The order must have an order_total, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['lines']
-        except KeyError as error:
-            new_msg = 'The order must have at least one order line, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'order_total' not in data:
+            raise KeyError('The order must have an order_total')
+        if 'lines' not in data:
+            raise KeyError('The order must have at least one order line')
         for line in data['lines']:
-            try:
-                test = line['id']
-            except KeyError as error:
-                new_msg = 'Each order line must have an id, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['product_id']
-            except KeyError as error:
-                new_msg = 'Each order line must have a product_id, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['product_variant_id']
-            except KeyError as error:
-                new_msg = 'Each order line must have a product_variant_id, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['quantity']
-            except KeyError as error:
-                new_msg = 'Each order line must have a quantity, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = line['price']
-            except KeyError as error:
-                new_msg = 'Each order line must have a price, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'id' not in line:
+                raise KeyError('Each order line must have an id')
+            if 'product_id' not in line:
+                raise KeyError('Each order line must have a product_id')
+            if 'product_variant_id' not in line:
+                raise KeyError('Each order line must have a product_variant_id')
+            if 'quantity' not in line:
+                raise KeyError('Each order line must have a quantity')
+            if 'price' not in line:
+                raise KeyError('Each order line must have a price')
         response = self._mc_client._post(url=self._build_path(store_id, 'orders'), data=data)
         if response is not None:
             self.order_id = response['id']

--- a/mailchimp3/entities/storeproducts.py
+++ b/mailchimp3/entities/storeproducts.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Products/Instance.
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storeproductvariants import StoreProductVariants
 
@@ -52,32 +49,17 @@ class StoreProducts(BaseApi):
         }
         """
         self.store_id = store_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The product must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['title']
-        except KeyError as error:
-            new_msg = 'The product must have a title, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['variants']
-        except KeyError as error:
-            new_msg = 'The product must have at least one variant, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The product must have an id')
+        if 'title' not in data:
+            raise KeyError('The product must have a title')
+        if 'variants' not in data:
+            raise KeyError('The product must have at least one variant')
         for variant in data['variants']:
-            try:
-                test = variant['id']
-            except KeyError as error:
-                new_msg = 'Each product variant must have an id, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-            try:
-                test = variant['title']
-            except KeyError as error:
-                new_msg = 'Each product variant must have a title, {}'.format(error)
-                six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+            if 'id' not in variant:
+                raise KeyError('Each product variant must have an id')
+            if 'title' not in variant:
+                raise KeyError('Each product variant must have a title')
         response = self._mc_client._post(url=self._build_path(store_id, 'products'), data=data)
         if response is not None:
             self.product_id = response['id']

--- a/mailchimp3/entities/storeproductvariants.py
+++ b/mailchimp3/entities/storeproductvariants.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Products/Variants/
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -47,16 +44,10 @@ class StoreProductVariants(BaseApi):
         """
         self.store_id = store_id
         self.product_id = product_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The product variant must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['title']
-        except KeyError as error:
-            new_msg = 'The product variant must have a title, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The product variant must have an id')
+        if 'title' not in data:
+            raise KeyError('The product variant must have a title')
         response = self._mc_client._post(url=self._build_path(store_id, 'products', product_id, 'variants'), data=data)
         if response is not None:
             self.variant_id = response['id']
@@ -155,16 +146,10 @@ class StoreProductVariants(BaseApi):
         self.store_id = store_id
         self.product_id = product_id
         self.variant_id = variant_id
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The product variant must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['title']
-        except KeyError as error:
-            new_msg = 'The product variant must have a title, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+             raise KeyError('The product variant must have an id')
+        if 'title' not in data:
+            raise KeyError('The product variant must have a title')
         return self._mc_client._put(
             url=self._build_path(store_id, 'products', product_id, 'variants', variant_id),
             data=data

--- a/mailchimp3/entities/stores.py
+++ b/mailchimp3/entities/stores.py
@@ -8,8 +8,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Ecommerce/Stores/Instance.json
 from __future__ import unicode_literals
 
 import re
-import six
-import sys
 
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.storecarts import StoreCarts
@@ -54,26 +52,14 @@ class Stores(BaseApi):
             "currency_code": string*
         }
         """
-        try:
-            test = data['id']
-        except KeyError as error:
-            new_msg = 'The store must have an id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['list_id']
-        except KeyError as error:
-            new_msg = 'The store must have a list_id, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The store must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['currency_code']
-        except KeyError as error:
-            new_msg = 'The store must have a currency_code, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'id' not in data:
+            raise KeyError('The store must have an id')
+        if 'list_id' not in data:
+            raise KeyError('The store must have a list_id')
+        if 'name' not in data:
+            raise KeyError('The store must have a name')
+        if 'currency_code' not in data:
+            raise KeyError('The store must have a currency_code')
         if not re.match(r"^[A-Z]{3}$", data['currency_code']):
             raise ValueError('The currency_code must be a valid 3-letter ISO 4217 currency code')
         response = self._mc_client._post(url=self._build_path(), data=data)

--- a/mailchimp3/entities/templatefolders.py
+++ b/mailchimp3/entities/templatefolders.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/TemplateFolders/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 
 
@@ -36,11 +33,8 @@ class TemplateFolders(BaseApi):
             "name": string*
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The template folder must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The template folder must have a name')
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.folder_id = response['id']
@@ -94,11 +88,8 @@ class TemplateFolders(BaseApi):
             "name": string*
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The template folder must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The template folder must have a name')
         self.folder_id = folder_id
         return self._mc_client._patch(url=self._build_path(folder_id), data=data)
 

--- a/mailchimp3/entities/templates.py
+++ b/mailchimp3/entities/templates.py
@@ -7,9 +7,6 @@ Schema: https://api.mailchimp.com/schema/3.0/Templates/Instance.json
 """
 from __future__ import unicode_literals
 
-import six
-import sys
-
 from mailchimp3.baseapi import BaseApi
 from mailchimp3.entities.templatedefaultcontent import TemplateDefaultContent
 
@@ -41,16 +38,10 @@ class Templates(BaseApi):
             "html": string*
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The template must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['html']
-        except KeyError as error:
-            new_msg = 'The template must have html, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The template must have a name')
+        if 'html' not in data:
+            raise KeyError('The template must have html')
         response = self._mc_client._post(url=self._build_path(), data=data)
         if response is not None:
             self.template_id = response['id']
@@ -110,16 +101,10 @@ class Templates(BaseApi):
             "html": string*
         }
         """
-        try:
-            test = data['name']
-        except KeyError as error:
-            new_msg = 'The template must have a name, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
-        try:
-            test = data['html']
-        except KeyError as error:
-            new_msg = 'The template must have html, {}'.format(error)
-            six.reraise(KeyError, KeyError(new_msg), sys.exc_info()[2])
+        if 'name' not in data:
+            raise KeyError('The template must have a name')
+        if 'html' not in data:
+            raise KeyError('The template must have html')
         self.template_id = template_id
         return self._mc_client._patch(url=self._build_path(template_id), data=data)
 

--- a/mailchimp3/helpers.py
+++ b/mailchimp3/helpers.py
@@ -72,7 +72,7 @@ def check_url(url):
     Used under MIT license.
 
     :param url:
-    :return:
+    :return: Nothing
     """
     URL_REGEX = re.compile(
     u"^"

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     ],
     keywords='mailchimp api v3 client wrapper',
     packages=find_packages(),
-    install_requires=['requests', 'six'],
+    install_requires=['requests'],
     # test_suite='tests',
 )


### PR DESCRIPTION
All try except blocks that were attempting to check data now use the
equivalent if statement and manually raise the appropriate error instead of
using the `six` library. The `six` library has been removed from the list of
required packages as well. There was a single try except block that did not
raise an error for the search-members endpoint that was used to populate one
of the local variables that has also been updated.