### PR TITLE
Add missing return statements

### DIFF
--- a/mailchimp3/entities/listgrowthhistory.py
+++ b/mailchimp3/entities/listgrowthhistory.py
@@ -41,7 +41,7 @@ class ListGrowthHistory(BaseApi):
         self.list_id = list_id
         self.month = None
         if get_all:
-            self._iterate(url=self._build_path(list_id, 'growth-history'), **queryparams)
+            return self._iterate(url=self._build_path(list_id, 'growth-history'), **queryparams)
         else:
             return self._mc_client._get(url=self._build_path(list_id, 'growth-history'), **queryparams)
 

--- a/mailchimp3/entities/listinterestcategoryinterest.py
+++ b/mailchimp3/entities/listinterestcategoryinterest.py
@@ -80,7 +80,7 @@ class ListInterestCategoryInterest(BaseApi):
         self.category_id = category_id
         self.interest_id = None
         if get_all:
-            self._iterate(url=self._build_path(list_id, 'interest-categories', category_id, 'interests'), **queryparams)
+            return self._iterate(url=self._build_path(list_id, 'interest-categories', category_id, 'interests'), **queryparams)
         else:
             return self._mc_client._get(
                 url=self._build_path(list_id, 'interest-categories', category_id, 'interests'),


### PR DESCRIPTION
There were two missing return statements making
```client.lists.interest_categories.interests.all```
and
```client.lists.growth_history.all```
return nothing with ```get_all=True``` set.