### PR TITLE
Make sure email address only contains non empty (sub-)domain parts

### DIFF
--- a/mailchimp3/helpers.py
+++ b/mailchimp3/helpers.py
@@ -58,7 +58,7 @@ def check_email(email):
     :type email: :py:class:`str`
     :return: Nothing
     """
-    if not re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email):
+    if not re.match(r"(^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+\.?$)", email):
         raise ValueError('String passed is not a valid email address')
     return
 


### PR DESCRIPTION
If an email address domain contains 2nd, 3rd, etc level sub-domains make sure they aren't empty. Previously something like user@domain..tld would've passed validation which causes MailChimp to be confused when doing an create-or-update request. I think they are doing some validation/cleanup on their side and this causes the subscriber hash to not match anymore.

That causes the following response when sending a PUT request to /list/$id/members/create_or_update:
```
{
  'detail': 'xxxxx@xxxxx..com is already a list member. Use PUT to insert or update list members.',
  'instance': '',
  'status': 400,
  'title': 'Member Exists',
  'type': 'http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/'
}
```

This commit changed the validation regex in the following way:
- Introduce a grouping around a (sub) domain part. This ensures that a domain part is accepted if it is not empty and ends with a .
- Moved the optional trailing dot for the domain root label (which is allowed to be there) after the validation of the top level domain