### PR TITLE
python2.6 bug ValueError: zero length field name in format

### DIFF
--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -48,7 +48,7 @@ class MailChimpClient(object):
         self.enabled = enabled
         self.auth = HTTPBasicAuth(mc_user, mc_secret)
         datacenter = mc_secret.split('-').pop()
-        self.base_url = 'https://{}.api.mailchimp.com/3.0/'.format(datacenter)
+        self.base_url = 'https://{0}.api.mailchimp.com/3.0/'.format(datacenter)
 
 
     @_enabled_or_noop


### PR DESCRIPTION
mailchimp3's format isn't compatible with python2.6.

```
  File "/usr/lib/python2.6/site-packages/mailchimp3/__init__.py", line 97, in __init__
    super(MailChimp, self).__init__(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/mailchimp3/mailchimpclient.py", line 51, in __init__
    self.base_url = 'https://{}.api.mailchimp.com/3.0/'.format(datacenter)
ValueError: zero length field name in format
```