### PR TITLE
BaseAPI unicode-compatibility fix

### DIFF
--- a/mailchimp3/baseapi.py
+++ b/mailchimp3/baseapi.py
@@ -2,6 +2,9 @@
 """
 The base API object that allows constructions of various endpoint paths
 """
+from __future__ import unicode_literals
+from itertools import chain
+
 from mailchimp3.helpers import  merge_results
 
 class BaseApi(object):
@@ -27,7 +30,7 @@ class BaseApi(object):
         :param args: Tokens in the endpoint URL
         :type args: :py:class:`str`
         """
-        return "/".join(str(component) for component in ([self.endpoint,] + list(args)))
+        return '/'.join(chain((self.endpoint,), args))
 
 
     def _iterate(self, url, **kwargs):


### PR DESCRIPTION
This fixes a unicode-compatibility error we encountered trying to use the mailchimp3 API wrapper in a Python2/3 codebase with the [python-future library](http://python-future.org) for compatibility. 

You can reproduce this error by running the following under Python 2:

```python

from __future__ import unicode_literals
from future import standard_library
standard_library.install_aliases()

from mailchimp3 import MailChimp

mc = MailChimp('username', 'apikey')

data = {
    'email_address' : 'email@example.com',
    'status' : 'subscribed',
    'ip_opt' : '127.0.0.1',
    'timestamp_opt': '2017-04-11T17:04:03.456642+00:00',
    'interests' : { 'group1' : True, 'group2': True },
}
response = mc.lists.members.create(list_id='12345', data=data)
```
This triggers the following error:

```
Traceback (most recent call last):
  File "example.py", line 16, in <module>
    response = mc.lists.members.create(list_id='12345', data=data)
  File "/home/bjmc/Sandbox/python-mailchimp/mailchimp3/entities/listmembers.py", line 57, in create
    response = self._mc_client._post(url=self._build_path(list_id, 'members'), data=data)
  File "/home/bjmc/Sandbox/python-mailchimp/mailchimp3/mailchimpclient.py", line 25, in wrapper
    return fn(self, *args, **kwargs)
  File "/home/bjmc/Sandbox/python-mailchimp/mailchimp3/mailchimpclient.py", line 65, in _post
    url = urljoin(self.base_url, url)
  File "/home/bjmc/Sandbox/python-mailchimp/.env/local/lib/python2.7/site-packages/future/backports/urllib/parse.py", line 418, in urljoin
    base, url, _coerce_result = _coerce_args(base, url)
  File "/home/bjmc/Sandbox/python-mailchimp/.env/local/lib/python2.7/site-packages/future/backports/urllib/parse.py", line 115, in _coerce_args
    raise TypeError("Cannot mix str and non-str arguments")
TypeError: Cannot mix str and non-str arguments
```

As best as I can determine, this error occurs because of the following:

* The `listmembers` module [imports unicode_literals](https://github.com/charlesthk/python-mailchimp/blob/master/mailchimp3/entities/listmembers.py#L8), so `self.endpoint` starts off as a unicode object.

* But then in baseapi, all the URL parameters are [coerced to being old-style Py2 str objects.](https://github.com/charlesthk/python-mailchimp/blob/master/mailchimp3/baseapi.py#L30)

* Later on, in `MailchimpClient._post()`, it [tries to `urljoin()`](https://github.com/charlesthk/python-mailchimp/blob/master/mailchimp3/mailchimpclient.py#L65) `self.base_url` (which is unicode) with the `url` parameter (a Py2 str)

* Because we ran `standard_library.install_aliases()`, the `urljoin()` function here is a backported Python3  version of urljoin, that enforces the separation of bytestrings and native (unicode) strings.

This changeset adds `from __future__ import unicode_literals` to `BaseAPI` and removes the str coercion from `_build_path()`. Basically, it allows unicode objects to just stay unicode.

This will make it easier for your users to maintain codebases that can run under either Python2 or Python3.