### PR TITLE
Removed the requirement of providing a username to the MailChimp constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Up to date with [changelog](http://developer.mailchimp.com/documentation/mailchi
 
 ### Initialization
 
-Grab `YOUR_SECRET_KEY` from your mailchimp account (Account > Extra >
-Api Keys). `YOUR_USERNAME` is the one you use to login.
+Grab `YOUR_API_KEY` from your mailchimp account (Account > Extra >
+API Keys). 
 
     from mailchimp3 import MailChimp
 
-    client = MailChimp('YOUR_USERNAME', 'YOUR_SECRET_KEY')
+    client = MailChimp('YOUR_API_KEY')
 
 ### Pagination
 
@@ -91,7 +91,7 @@ display email_address and id for each member in list 123456:
 
     # You can also disable at runtime with the optional ``enabled`` parameter.
     # Every API call will return None
-    client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', enabled=False)
+    client = MailChimp('YOUR_API_KEY', enabled=False)
 
 ## API Structure
 

--- a/README.rst
+++ b/README.rst
@@ -37,14 +37,14 @@ features listed thru 1/12/2017.
 Initialization
 ~~~~~~~~~~~~~~
 
-Grab ``YOUR_SECRET_KEY`` from your mailchimp account (Account > Extra >
-Api Keys). ``YOUR_USERNAME`` is the one you use to login.
+Grab ``YOUR_API_KEY`` from your mailchimp account (Account > Extra >
+Api Keys).
 
 ::
 
     from mailchimp3 import MailChimp
 
-    client = MailChimp('YOUR_USERNAME', 'YOUR_SECRET_KEY')
+    client = MailChimp('YOUR_API_KEY')
 
 Pagination
 ~~~~~~~~~~
@@ -109,7 +109,7 @@ Examples
 
     # You can also disable at runtime with the optional ``enabled`` parameter.
     # Every API call will return None
-    client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', enabled=False)
+    client = MailChimp('YOUR_API_KEY', enabled=False)
 
 API Structure
 -------------

--- a/mailchimp3/__init__.py
+++ b/mailchimp3/__init__.py
@@ -90,9 +90,14 @@ class MailChimp(MailChimpClient):
     """
     def __init__(self, *args, **kwargs):
         """
-        Initialize the class with your user_id and secret_key and attach all
-        of the endpoints
+        Initialize the class with your api_key and attach all
+        of the endpoints.
         """
+        if len(args) == 2:
+            # For backwards compatibility with v2.0.10, we need to accept the
+            # MailChimp('username', 'api_key') format, even though we don't
+            # use the provided username any more.
+            args = args[1:]
         super(MailChimp, self).__init__(*args, **kwargs)
         # API Root
         self.root = self.api_root = Root(self)

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -30,24 +30,23 @@ class MailChimpClient(object):
     """
     MailChimp class to communicate with the v3 API
     """
-    def __init__(self, mc_user, mc_secret, enabled=True):
+    def __init__(self, api_key, enabled=True):
         """
-        Initialize the class with you user_id and secret_key.
+        Initialize the class with the given API key.
 
         If `enabled` is not True, these methods become no-ops. This is
         particularly useful for testing or disabling with configuration.
 
-        :param mc_user: Mailchimp user id
-        :type mc_user: :py:class:`str`
-        :param mc_secret: Mailchimp secret key
-        :type mc_secret: :py:class:`str`
+        :param api_key: Mailchimp API key
+        :type api_key: :py:class:`str`
         :param enabled: Whether the API should execute any requests
         :type enabled: :py:class:`bool`
         """
         super(MailChimpClient, self).__init__()
         self.enabled = enabled
-        self.auth = HTTPBasicAuth(mc_user, mc_secret)
-        datacenter = mc_secret.split('-').pop()
+        # MailChimp's HTTP Basic Auth accepts any string for the username.
+        self.auth = HTTPBasicAuth('user', api_key)
+        datacenter = api_key.split('-').pop()
         self.base_url = 'https://{0}.api.mailchimp.com/3.0/'.format(datacenter)
 
 

--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ Some basic tests to verify that the wrapper is working
 from mailchimp3 import MailChimp
 
 
-client = MailChimp('MAILCHIMP_USER', 'MAILCHIMP_SECRET')
+client = MailChimp('MAILCHIMP_API_KEY')
 
 print client.lists.all(fields="lists.name,lists.id")
 


### PR DESCRIPTION
As discussed in #119, The MailChimp API doesn't care what string you use as the
username for the HTTP Basic Auth. So this PR removes the username from the
required parameters, while being backwards compatible with existing code that
calls MailChimp('username', 'apikey').