### PR TITLE
Updated the batches code to allow DELETE.

### DIFF
--- a/mailchimp3/entities/batches.py
+++ b/mailchimp3/entities/batches.py
@@ -34,7 +34,7 @@ class Batches(BaseApi):
             "operations": array*
             [
                 {
-                    "method": string* (Must be one of "GET", "POST", "PUT", or "PATCH")
+                    "method": string* (Must be one of "GET", "POST", "PUT", "PATCH", or "DELETE")
                     "path": string*,
                 }
             ]
@@ -45,9 +45,9 @@ class Batches(BaseApi):
         for op in data['operations']:
             if 'method' not in op:
                 raise KeyError('The batch operation must have a method')
-            if op['method'] not in ['GET', 'POST', 'PUT', 'PATCH']:
-                raise ValueError('The batch operation method must be one of "GET", "POST", "PUT", or "PATCH", not {0}'
-                                 ''.format(op['method']))
+            if op['method'] not in ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']:
+                raise ValueError('The batch operation method must be one of "GET", "POST", "PUT", "PATCH", '
+                                 'or "DELETE", not {0}'.format(op['method']))
             if 'path' not in op:
                 raise KeyError('The batch operation must have a path')
         return self._mc_client._post(url=self._build_path(), data=data)


### PR DESCRIPTION
I spoke with the MailChimp API team over the weekend, due to the strangeness of the apparent lack of support for DELETE in the batches API. Turns out that they do support batched DELETEs; it's just that their docs are out of date. You can test this by posting the following directly to the batches API:

```
{
    "operations": [
        {
            "method": "DELETE",
            "path": "/lists/<list_id>/members/<subscriber_hash>"
        }
    ]
}
```

The person I spoke with assures me that the developers have been notified that they should update the API docs. Though I don't know how long that will take to propagate to the [live docs page](http://developer.mailchimp.com/documentation/mailchimp/reference/batches/).

My project needs this feature pretty urgently, so I would very much appreciate this PR being integrated into a new PyPI release as soon as possible.