### PR TITLE
Add timeout parameter to MailChimpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ display email_address and id for each member in list 123456:
     # Every API call will return None
     client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', enabled=False)
 
+    # You are encouraged to specify a value in seconds for the  ``timeout`` 
+    # parameter to avoid hanging requests.
+    client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', timeout=10.0)
+
 ## API Structure
 
 All endpoints follow the structure listed in the official MailChimp API

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,10 @@ Examples
     # Every API call will return None
     client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', enabled=False)
 
+    # You are encouraged to specify a value in seconds for the  ``timeout``
+    # parameter to avoid hanging requests.
+    client = MailChimp('YOUR USERNAME', 'YOUR SECRET KEY', timeout=10.0)
+
 API Structure
 -------------
 

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -30,7 +30,7 @@ class MailChimpClient(object):
     """
     MailChimp class to communicate with the v3 API
     """
-    def __init__(self, mc_user, mc_secret, enabled=True):
+    def __init__(self, mc_user, mc_secret, enabled=True, timeout=None):
         """
         Initialize the class with you user_id and secret_key.
 
@@ -43,9 +43,14 @@ class MailChimpClient(object):
         :type mc_secret: :py:class:`str`
         :param enabled: Whether the API should execute any requests
         :type enabled: :py:class:`bool`
+        :param timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float, or a :ref:`(connect timeout,
+            read timeout) <timeouts>` tuple.
+        :type timeout: float or tuple
         """
         super(MailChimpClient, self).__init__()
         self.enabled = enabled
+        self.timeout = timeout
         self.auth = HTTPBasicAuth(mc_user, mc_secret)
         datacenter = mc_secret.split('-').pop()
         self.base_url = 'https://{0}.api.mailchimp.com/3.0/'.format(datacenter)
@@ -64,7 +69,7 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.post(url, auth=self.auth, json=data)
+            r = requests.post(url, auth=self.auth, json=data, timeout=self.timeout)
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -88,7 +93,7 @@ class MailChimpClient(object):
         if len(queryparams):
             url += '?' + urlencode(queryparams)
         try:
-            r = requests.get(url, auth=self.auth)
+            r = requests.get(url, auth=self.auth, timeout=self.timeout)
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -107,7 +112,7 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.delete(url, auth=self.auth)
+            r = requests.delete(url, auth=self.auth, timeout=self.timeout)
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -130,7 +135,7 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.patch(url, auth=self.auth, json=data)
+            r = requests.patch(url, auth=self.auth, json=data, timeout=self.timeout)
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -151,7 +156,7 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.put(url, auth=self.auth, json=data)
+            r = requests.put(url, auth=self.auth, json=data, timeout=self.timeout)
         except requests.exceptions.RequestException as e:
             raise e
         else:


### PR DESCRIPTION
It was possible that network requests would hang indefinetly and crash our app when using MailChimpClient. We were using it in a Celery task, and that task would then hang indefinetly.

Even Celery's documentation warns against using the requests library without specifying a timeout.

```
Warning

A task that blocks indefinitely may eventually stop the worker instance from doing any other work.

If you task does I/O then make sure you add timeouts to these operations, like adding a timeout to a web request using the requests library:

connect_timeout, read_timeout = 5.0, 30.0
response = requests.get(URL, timeout=(connect_timeout, read_timeout))

Time limits are convenient for making sure all tasks return in a timely manner, but a time limit event will actually kill the process by force so only use them to detect cases where you haven’t used manual timeouts yet.

The default prefork pool scheduler is not friendly to long-running tasks, so if you have tasks that run for minutes/hours make sure you enable the -Ofair`` command-line argument to the celery worker. See Prefork pool prefetch settings for more information, and for the best performance route long-running and short-running tasks to dedicated workers (Automatic routing).

If your worker hangs then please investigate what tasks are running before submitting an issue, as most likely the hanging is caused by one or more tasks hanging on a network operation.
```