### PR TITLE
add mailchimp3.client logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mailchimp3 v2.0.11 on PyPi](https://img.shields.io/badge/pypi-2.0.11-green.svg)](https://pypi.python.org/pypi/mailchimp3)
+[![mailchimp3 v2.0.16 on PyPi](https://img.shields.io/badge/pypi-2.0.16-green.svg)](https://pypi.python.org/pypi/mailchimp3)
 ![MIT license](https://img.shields.io/badge/licence-MIT-blue.svg)
 ![Stable](https://img.shields.io/badge/status-stable-green.svg)
 
@@ -575,6 +575,29 @@ above with the name `client`.
 #### Default Content
 
     client.templates.default_content.all(template_id='')
+
+## Logging
+
+The MailChimp client will log request/response detail into the mailchimp3.client
+logging namespace. Consider the following snippet to get started with logging:
+
+```python
+import logging
+fh = logging.FileHandler('/path/to/some/log.log')
+logger = logging.getLogger('mailchimp3.client')
+logger.addHandler(fh)
+
+# use the client normally
+client.lists.all(**{'fields': 'lists.date_created'})
+```
+
+request/response detail will be appended into /path/to/some/log.log:
+```
+GET Request: https://us15.api.mailchimp.com/3.0/lists?fields=lists.date_created
+GET Response: 200 {"lists":[{"date_created":"2017-05-10T13:53:05+00:00"},{"date_created":"2017-08-22T20:27:56+00:00"},{"date_created":"2017-05-12T21:22:15+00:00"},{"date_created":"2017-04-27T17:42:04+00:00"},{"date_created":"2017-05-10T14:14:49+00:00"},{"date_created":"2017-05-10T13:52:37+00:00"},{"date_created":"2017-05-10T13:51:40+00:00"}]}
+```
+
+Check the [docs](https://docs.python.org/2/library/logging.html) for more detail on the Python logging package.
 
 ## Support
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|mailchimp3 v2.0.11 on PyPi| |MIT license| |Stable|
+|mailchimp3 v2.0.16 on PyPi| |MIT license| |Stable|
 
 python-mailchimp-api
 ====================
@@ -790,6 +790,33 @@ Default Content
 
     client.templates.default_content.all(template_id='')
 
+Logging
+-------
+
+The MailChimp client will log request/response detail into the mailchimp3.client
+logging namespace. Consider the following snippet to get started with logging:
+
+::
+
+    import logging
+    fh = logging.FileHandler('/path/to/some/log.log')
+    logger = logging.getLogger('mailchimp3.client')
+    logger.addHandler(fh)
+
+    # use the client normally
+    client.lists.all(**{'fields': 'lists.date_created'})
+
+request/response detail will be appended into /path/to/some/log.log:
+
+::
+
+    GET Request: https://us15.api.mailchimp.com/3.0/lists?fields=lists.date_created
+    GET Response: 200 {"lists":[{"date_created":"2017-05-10T13:53:05+00:00"},{"date_created":"2017-08-22T20:27:56+00:00"},{"date_created":"2017-05-12T21:22:15+00:00"},{"date_created":"2017-04-27T17:42:04+00:00"},{"date_created":"2017-05-10T14:14:49+00:00"},{"date_created":"2017-05-10T13:52:37+00:00"},{"date_created":"2017-05-10T13:51:40+00:00"}]}
+
+Check the docs_ for more detail on the Python logging package.
+
+.. _docs: https://docs.python.org/2/library/logging.html/
+
 Support
 -------
 
@@ -800,8 +827,7 @@ License
 
 The project is licensed under the MIT License.
 
-.. |mailchimp3 v2.0.11 on PyPi| image:: https://img.shields.io/badge/pypi-2.0.11-green.svg
+.. |mailchimp3 v2.0.16 on PyPi| image:: https://img.shields.io/badge/pypi-2.0.16-green.svg
    :target: https://pypi.python.org/pypi/mailchimp3
 .. |MIT license| image:: https://img.shields.io/badge/licence-MIT-blue.svg
 .. |Stable| image:: https://img.shields.io/badge/status-stable-green.svg
-

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -17,6 +17,9 @@ except ImportError:
     from urlparse import urljoin
     from urllib import urlencode
 
+import logging
+
+_logger = logging.getLogger('mailchimp3.client')
 
 def _enabled_or_noop(fn):
     @functools.wraps(fn)
@@ -56,6 +59,19 @@ class MailChimpClient(object):
         self.base_url = 'https://{0}.api.mailchimp.com/3.0/'.format(datacenter)
 
 
+    def _make_request(self, **kwargs):
+        _logger.info(u'{method} Request: {url}'.format(**kwargs))
+        if 'json' in kwargs:
+            _logger.info('PAYLOAD: {json}'.format(**kwargs))
+
+        response = requests.request(**kwargs)
+
+        _logger.info(u'{method} Response: {status} {text}'\
+            .format(method=kwargs['method'], status=response.status_code, text=response.text))
+
+        return response
+
+
     @_enabled_or_noop
     def _post(self, url, data=None):
         """
@@ -69,7 +85,13 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.post(url, auth=self.auth, json=data, timeout=self.timeout)
+            r = self._make_request(**{
+                'method': 'POST',
+                'url': url,
+                'json': data,
+                'auth': self.auth,
+                'timeout': self.timeout
+            })
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -93,7 +115,12 @@ class MailChimpClient(object):
         if len(queryparams):
             url += '?' + urlencode(queryparams)
         try:
-            r = requests.get(url, auth=self.auth, timeout=self.timeout)
+            r = self._make_request(**{
+                'method': 'GET',
+                'url': url,
+                'auth': self.auth,
+                'timeout': self.timeout
+            })
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -112,7 +139,12 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.delete(url, auth=self.auth, timeout=self.timeout)
+            r = self._make_request(**{
+                'method': 'DELETE',
+                'url': url,
+                'auth': self.auth,
+                'timeout': self.timeout
+            })
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -135,7 +167,13 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.patch(url, auth=self.auth, json=data, timeout=self.timeout)
+            r = self._make_request(**{
+                'method': 'PATCH',
+                'url': url,
+                'json': data,
+                'auth': self.auth,
+                'timeout': self.timeout
+            })
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -156,7 +194,13 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = requests.put(url, auth=self.auth, json=data, timeout=self.timeout)
+            r = self._make_request(**{
+                'method': 'PUT',
+                'url': url,
+                'json': data,
+                'auth': self.auth,
+                'timeout': self.timeout
+            })
         except requests.exceptions.RequestException as e:
             raise e
         else:

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -33,7 +33,7 @@ class MailChimpClient(object):
     """
     MailChimp class to communicate with the v3 API
     """
-    def __init__(self, mc_user, mc_secret, enabled=True, timeout=None):
+    def __init__(self, mc_user, mc_secret, enabled=True, timeout=None, request_hooks=None):
         """
         Initialize the class with you user_id and secret_key.
 
@@ -57,11 +57,12 @@ class MailChimpClient(object):
         self.auth = HTTPBasicAuth(mc_user, mc_secret)
         datacenter = mc_secret.split('-').pop()
         self.base_url = 'https://{0}.api.mailchimp.com/3.0/'.format(datacenter)
+        self.request_hooks = request_hooks or requests.hooks.default_hooks()
 
 
     def _make_request(self, **kwargs):
         _logger.info(u'{method} Request: {url}'.format(**kwargs))
-        if 'json' in kwargs:
+        if kwargs.get('json'):
             _logger.info('PAYLOAD: {json}'.format(**kwargs))
 
         response = requests.request(**kwargs)
@@ -85,13 +86,14 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = self._make_request(**{
-                'method': 'POST',
-                'url': url,
-                'json': data,
-                'auth': self.auth,
-                'timeout': self.timeout
-            })
+            r = self._make_request(**dict(
+                method='POST',
+                url=url,
+                json=data,
+                auth=self.auth,
+                timeout=self.timeout,
+                hooks=self.request_hooks
+            ))
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -115,12 +117,13 @@ class MailChimpClient(object):
         if len(queryparams):
             url += '?' + urlencode(queryparams)
         try:
-            r = self._make_request(**{
-                'method': 'GET',
-                'url': url,
-                'auth': self.auth,
-                'timeout': self.timeout
-            })
+            r = self._make_request(**dict(
+                method='GET',
+                url=url,
+                auth=self.auth,
+                timeout=self.timeout,
+                hooks=self.request_hooks
+            ))
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -139,12 +142,13 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = self._make_request(**{
-                'method': 'DELETE',
-                'url': url,
-                'auth': self.auth,
-                'timeout': self.timeout
-            })
+            r = self._make_request(**dict(
+                method='DELETE',
+                url=url,
+                auth=self.auth,
+                timeout=self.timeout,
+                hooks=self.request_hooks
+            ))
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -167,13 +171,14 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = self._make_request(**{
-                'method': 'PATCH',
-                'url': url,
-                'json': data,
-                'auth': self.auth,
-                'timeout': self.timeout
-            })
+            r = self._make_request(**dict(
+                method='PATCH',
+                url=url,
+                json=data,
+                auth=self.auth,
+                timeout=self.timeout,
+                hooks=self.request_hooks
+            ))
         except requests.exceptions.RequestException as e:
             raise e
         else:
@@ -194,13 +199,14 @@ class MailChimpClient(object):
         """
         url = urljoin(self.base_url, url)
         try:
-            r = self._make_request(**{
-                'method': 'PUT',
-                'url': url,
-                'json': data,
-                'auth': self.auth,
-                'timeout': self.timeout
-            })
+            r = self._make_request(**dict(
+                method='PUT',
+                url=url,
+                json=data,
+                auth=self.auth,
+                timeout=self.timeout,
+                hooks=self.request_hooks
+            ))
         except requests.exceptions.RequestException as e:
             raise e
         else:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='mailchimp3',
-    version='2.0.11',
+    version='2.0.16',
     description='A python client for v3 of MailChimp API',
     long_description=long_description,
     url='https://github.com/charlesthk/python-mailchimp',


### PR DESCRIPTION
this PR adds a generic _make_requests method to capture logging on all client requests/responses

```python
import logging
logger = logging.getLogger('mailchimp3.client')
logger.addHandler(some_log_file)
```