### PR TITLE
Fixed typos

### DIFF
--- a/mailchimp3/entities/lists.py
+++ b/mailchimp3/entities/lists.py
@@ -61,7 +61,7 @@ class Lists(BaseApi):
                 "zip": string*,
                 "country": string*
             },
-            "permision_reminder": string*,
+            "permission_reminder": string*,
             "campaign_defaults": object*
             {
                 "from_name": string*,
@@ -222,7 +222,7 @@ class Lists(BaseApi):
                 "zip": string*,
                 "country": string*
             },
-            "permision_reminder": string*,
+            "permission_reminder": string*,
             "campaign_defaults": object*
             {
                 "from_name": string*,


### PR DESCRIPTION
In the data examples in the comments for the lists, permission_reminder was mispelt.

This has been fixed across the file.