### PR TITLE
Add query string params for automation single workflow endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mailchimp3 v2.0.13 on PyPi](https://img.shields.io/badge/pypi-2.0.13-green.svg)](https://pypi.python.org/pypi/mailchimp3)
+[![mailchimp3 v2.0.14 on PyPi](https://img.shields.io/badge/pypi-2.0.14-green.svg)](https://pypi.python.org/pypi/mailchimp3)
 ![MIT license](https://img.shields.io/badge/licence-MIT-blue.svg)
 ![Stable](https://img.shields.io/badge/status-stable-green.svg)
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|mailchimp3 v2.0.13 on PyPi| |MIT license| |Stable|
+|mailchimp3 v2.0.14 on PyPi| |MIT license| |Stable|
 
 python-mailchimp-api
 ====================
@@ -801,7 +801,7 @@ License
 
 The project is licensed under the MIT License.
 
-.. |mailchimp3 v2.0.13 on PyPi| image:: https://img.shields.io/badge/pypi-2.0.13-green.svg
+.. |mailchimp3 v2.0.14 on PyPi| image:: https://img.shields.io/badge/pypi-2.0.14-green.svg
    :target: https://pypi.python.org/pypi/mailchimp3
 .. |MIT license| image:: https://img.shields.io/badge/licence-MIT-blue.svg
 .. |Stable| image:: https://img.shields.io/badge/status-stable-green.svg

--- a/mailchimp3/entities/automations.py
+++ b/mailchimp3/entities/automations.py
@@ -52,7 +52,7 @@ class Automations(BaseApi):
 
 
     # Paid feature
-    def get(self, workflow_id):
+    def get(self, workflow_id, **queryparams):
         """
         Get a summary of an individual Automation workflow’s settings and
         content. The trigger_settings object returns information for the first
@@ -60,6 +60,9 @@ class Automations(BaseApi):
 
         :param workflow_id: The unique id for the Automation workflow
         :type workflow_id: :py:class:`str`
+        :param queryparams: the query string parameters
+        queryparams['fields'] = []
+        queryparams['exclude_fields'] = []
         """
         self.workflow_id = workflow_id
-        return self._mc_client._get(url=self._build_path(workflow_id))
+        return self._mc_client._get(url=self._build_path(workflow_id), **queryparams)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='mailchimp3',
-    version='2.0.13',
+    version='2.0.14',
     description='A python client for v3 of MailChimp API',
     long_description=long_description,
     url='https://github.com/charlesthk/python-mailchimp',


### PR DESCRIPTION
This addresses #140 and also bumps up the minor version.

Tested with mailchimp API. See logs below.

```bash
$ mkvirtualenv test-mailchimp3

(test-mailchimp3) $ python setup.py install 
running install
...
Installed /Users/ye/.envs/test-mailchimp3/lib/python3.6/site-packages/chardet-3.0.4-py3.6.egg
Finished processing dependencies for mailchimp3==2.0.14

(test-mailchimp3) $ pip install ipython

(test-mailchimp3) $ ipython
Python 3.6.1 (default, Apr  4 2017, 09:40:51) 
Type 'copyright', 'credits' or 'license' for more information
IPython 6.1.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from mailchimp3 import MailChimp

In [2]: client = MailChimp('', 'XXXXXXXXXXXXX-us1')

In [3]: client.automations.get('xxxxxxxxxx', fields='emails_sent')
Out[3]: {'emails_sent': 16}

In [4]: client.automations.get('xxxxxxxxxx', exclude_fields='_links, automations._links')
Out[4]: 
{'create_time': '2016-04-15T15:53:21+00:00',
 'emails_sent': 16,
 'id': 'xxxxxxxxxx',
 'recipients': {'list_id': 'xxxxxxxxxx', 'list_name': 'Customers'},
 'report_summary': {'click_rate': 0,
  'clicks': 0,
  'open_rate': 0.11111111111111,
  'opens': 1,
  'subscriber_clicks': 0,
  'unique_opens': 1},
 'settings': {'authenticate': True,
  'auto_footer': False,
  'from_name': 'Test Automation Works',
  'inline_css': False,
  'reply_to': 'test@test.com',
  'title': 'Test Automation Works #4',
  'to_name': '',
  'use_conversation': False},
 'start_time': '2016-04-15T16:52:13+00:00',
 'status': 'sending',
 'tracking': {'clicktale': '',
  'ecomm360': False,
  'goal_tracking': False,
  'google_analytics': '',
  'html_clicks': True,
  'opens': True,
  'text_clicks': True},
 'trigger_settings': {'runtime': {'days': ['sunday',
    'monday',
    'tuesday',
    'wednesday',
    'thursday',
    'friday',
    'saturday'],
   'hours': {'type': 'automation'}},
  'workflow_emails_count': 5,
  'workflow_title': 'Specific Date',
  'workflow_type': 'specialEvent'}}

In [5]: client.automations.get?
Signature: client.automations.get(workflow_id, **queryparams)
Docstring:
Get a summary of an individual Automation workflow’s settings and
content. The trigger_settings object returns information for the first
email in the workflow.

:param workflow_id: The unique id for the Automation workflow
:type workflow_id: :py:class:`str`
:param queryparams: the query string parameters
queryparams['fields'] = []
queryparams['exclude_fields'] = []
File:      ~/dev/python-mailchimp/mailchimp3/entities/automations.py
Type:      method

(test-mailchimp3) $ pip freeze | grep mailchimp3
mailchimp3==2.0.14
```