### PR TITLE
Add query params (get_all, fields, exclude_fields) for Automations Workflow Emails Get All endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mailchimp3 v2.0.14 on PyPi](https://img.shields.io/badge/pypi-2.0.14-green.svg)](https://pypi.python.org/pypi/mailchimp3)
+[![mailchimp3 v2.0.15 on PyPi](https://img.shields.io/badge/pypi-2.0.15-green.svg)](https://pypi.python.org/pypi/mailchimp3)
 ![MIT license](https://img.shields.io/badge/licence-MIT-blue.svg)
 ![Stable](https://img.shields.io/badge/status-stable-green.svg)
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|mailchimp3 v2.0.14 on PyPi| |MIT license| |Stable|
+|mailchimp3 v2.0.15 on PyPi| |MIT license| |Stable|
 
 python-mailchimp-api
 ====================
@@ -801,7 +801,7 @@ License
 
 The project is licensed under the MIT License.
 
-.. |mailchimp3 v2.0.14 on PyPi| image:: https://img.shields.io/badge/pypi-2.0.14-green.svg
+.. |mailchimp3 v2.0.15 on PyPi| image:: https://img.shields.io/badge/pypi-2.0.15-green.svg
    :target: https://pypi.python.org/pypi/mailchimp3
 .. |MIT license| image:: https://img.shields.io/badge/licence-MIT-blue.svg
 .. |Stable| image:: https://img.shields.io/badge/status-stable-green.svg

--- a/mailchimp3/entities/automationemails.py
+++ b/mailchimp3/entities/automationemails.py
@@ -31,16 +31,24 @@ class AutomationEmails(BaseApi):
 
 
     # Paid feature
-    def all(self, workflow_id):
+    def all(self, workflow_id, get_all=False, **queryparams):
         """
         Get a summary of the emails in an Automation workflow.
 
         :param workflow_id: The unique id for the Automation workflow.
         :type workflow_id: :py:class:`str`
+        :param get_all: Should the query get all results
+        :type get_all: :py:class:`bool`
+        :param queryparams: the query string parameters
+        queryparams['fields'] = []
+        queryparams['exclude_fields'] = []
         """
         self.workflow_id = workflow_id
         self.email_id = None
-        return self._mc_client._get(url=self._build_path(workflow_id, 'emails'))
+        if get_all:
+            return self._iterate(url=self._build_path(workflow_id, 'emails'), **queryparams)
+        else:
+            return self._mc_client._get(url=self._build_path(workflow_id, 'emails'), **queryparams)
 
 
     # Paid feature

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='mailchimp3',
-    version='2.0.14',
+    version='2.0.15',
     description='A python client for v3 of MailChimp API',
     long_description=long_description,
     url='https://github.com/charlesthk/python-mailchimp',


### PR DESCRIPTION
This should address majority of the issues in #143 and also bump up minor version to 2.0.15.

Verified `get_all` and `fields` filter query params with our live mailchimp account which has 37 automation workflow email campaigns, which previously only returns 10 items even though `total_items` indicates there are more than 10 email campaigns available.

```python
In [1]: import mailchimp3

In [2]: mc = mailchimp3.MailChimp('', 'xxxxxxxx-us1')

In [3]: mc.automations.emails.all('WORKFLOW_ID', get_all=True, exclude_fields='emails,_links')
Out[3]: {'total_items': 37}

In [4]: mc.automations.emails.all('WORKFLOW_ID', get_all=True, fields='emails.settings.title,total_items')
Out[4]: 
{'emails': [{'settings': {'title': 'Week 5'}},
  {'settings': {'title': 'Week 11'}},
  {'settings': {'title': 'Week 29'}},
  {'settings': {'title': 'Week 21'}},
  {'settings': {'title': 'Week 37'}},
  {'settings': {'title': 'Week 23'}},
  {'settings': {'title': 'Week 10'}},
  {'settings': {'title': 'Week 9'}},
  {'settings': {'title': 'Week 30'}},
  {'settings': {'title': 'Week 7'}},
  {'settings': {'title': 'Week 40'}},
  {'settings': {'title': 'Week 33'}},
  {'settings': {'title': 'Week 17'}},
  {'settings': {'title': 'Week 25'}},
  {'settings': {'title': 'Week 31'}},
  {'settings': {'title': 'Week 18'}},
  {'settings': {'title': 'Week 12'}},
  {'settings': {'title': 'Week 4'}},
  {'settings': {'title': 'Week 19'}},
  {'settings': {'title': 'Week 39'}},
  {'settings': {'title': 'Week 28'}},
  {'settings': {'title': 'Week 36'}},
  {'settings': {'title': 'Week 15'}},
  {'settings': {'title': 'Week 27'}},
  {'settings': {'title': 'Week 26'}},
  {'settings': {'title': 'Week 6'}},
  {'settings': {'title': 'Week 35'}},
  {'settings': {'title': 'Week 14'}},
  {'settings': {'title': 'Week 34'}},
  {'settings': {'title': 'Week 13'}},
  {'settings': {'title': 'Week 38'}},
  {'settings': {'title': 'Week 8'}},
  {'settings': {'title': 'Week 24'}},
  {'settings': {'title': 'Week 22'}},
  {'settings': {'title': 'Week 16'}},
  {'settings': {'title': 'Week 32'}},
  {'settings': {'title': 'Week 20'}}],
 'total_items': 37}

In [5]: len(_['emails'])
Out[5]: 37

In [6]: workflow_emails = mc.automations.emails.all('WORKFLOW_ID')

In [7]: len(workflow_emails['emails'])
Out[7]: 10

```