### PR TITLE
Fix bug where invalid email type being checked against for campaign.a…

### DIFF
--- a/mailchimp3/entities/campaignactions.py
+++ b/mailchimp3/entities/campaignactions.py
@@ -125,13 +125,13 @@ class CampaignActions(BaseApi):
         :type data: :py:class:`dict`
         data = {
             "test_emails": array*,
-            "send_type": string* (Must be one of "html" or "plain_text")
+            "send_type": string* (Must be one of "html" or "plaintext")
         }
         """
         for email in data['test_emails']:
             check_email(email)
-        if data['send_type'] not in ['html', 'plain_text']:
-            raise ValueError('The send_type must be either "html" or "plain_text"')
+        if data['send_type'] not in ['html', 'plaintext']:
+            raise ValueError('The send_type must be either "html" or "plaintext"')
         self.campaign_id = campaign_id
         return self._mc_client._post(url=self._build_path(campaign_id, 'actions/test'), data=data)
 


### PR DESCRIPTION
According to the [MailChimp API documentation](https://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#action-post_campaigns_campaign_id_actions_test) the valid data attribute for `send_type` to allow sending of plain text test emails is `plaintext`, not `plain_text` as is currently implemented in this package. 

Without this fix, setting `send_type` as `plain_text` results in a 400 status from the MailChimp API while setting as `plaintext` results in a local exception being raised preventing sending of plain text test emails.